### PR TITLE
Fix: Results view is too narrow when no images are present

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -318,7 +318,6 @@ class PollBlock(PollBase):
         total = 0
         self.clean_tally()
         source_tally = self.tally
-        any_img = self.any_image(self.answers)
         for key, value in answers.items():
             count = int(source_tally[key])
             tally.append({
@@ -330,7 +329,6 @@ class PollBlock(PollBase):
                 'first': False,
                 'choice': False,
                 'last': False,
-                'any_img': any_img,
             })
             total += count
 
@@ -437,9 +435,13 @@ class PollBlock(PollBase):
             self.publish_event_from_dict(self.event_namespace + '.view_results', {})
             detail, total = self.tally_detail()
         return {
-            'question': markdown(self.question), 'tally': detail,
-            'total': total, 'feedback': markdown(self.feedback),
-            'plural': total > 1, 'display_name': self.display_name,
+            'question': markdown(self.question),
+            'tally': detail,
+            'total': total,
+            'feedback': markdown(self.feedback),
+            'plural': total > 1,
+            'display_name': self.display_name,
+            'any_img': self.any_image(self.answers),
         }
 
     @XBlock.json_handler

--- a/poll/public/css/poll.css
+++ b/poll/public/css/poll.css
@@ -38,10 +38,14 @@
 
 .percentage-gauge-container {
     display: inline-block;
-    width: 65%;
+    width: 87%;
     vertical-align: middle;
     position: relative;
     background-color: #fafbfc;
+}
+
+.poll-results.has-images .percentage-gauge-container {
+    width: 65%;
 }
 
 ul.poll-answers, ul.poll-answers-results {

--- a/poll/public/handlebars/poll_results.handlebars
+++ b/poll/public/handlebars/poll_results.handlebars
@@ -1,13 +1,13 @@
 <script id="poll-results-template" type="text/html">
     <h3 class="poll-header">{{display_name}}</h3>
     <div class="poll-question-container">{{{question}}}</div>
-    <ul class="poll-answers-results poll-results">
+    <ul class="poll-answers-results poll-results {{~#if any_img}} has-images{{/if}}">
     {{#each tally}}
         <li class="poll-result">
             <div class="poll-result-input-container">
               <input id="answer-{{key}}" type="radio" disabled {{#if choice}}checked{{/if}} />
             </div>
-            {{~#if any_img~}}
+            {{~#if ../any_img~}}
                 <div class="poll-image result-image">
                     <label for="answer-{{key}}" class="poll-image-label">
                         {{#if img}}


### PR DESCRIPTION
Fix for width issue reported in MCKIN-3599 on the results screen: If a poll contains no images, the results are not as wide as they should be.

**Before**:
![before](https://cloud.githubusercontent.com/assets/945577/11013561/9ee93eb0-84c7-11e5-9c28-3e50230a229b.png)

**After**:
![after](https://cloud.githubusercontent.com/assets/945577/11013562/aa523b58-84c7-11e5-9327-96e9d624fd31.png)
