### PR TITLE
A11y fixes

### DIFF
--- a/poll/public/handlebars/poll_results.handlebars
+++ b/poll/public/handlebars/poll_results.handlebars
@@ -1,40 +1,43 @@
-<script id="poll-results-template" type="text/html">
+<script class="poll-results-template" type="text/html">
     <h3 class="poll-header">{{display_name}}</h3>
     <div class="poll-question-container">{{{question}}}</div>
-    <ul class="poll-answers-results poll-results {{~#if any_img}} has-images{{/if}}">
-    {{#each tally}}
-        <li class="poll-result">
-            <div class="poll-result-input-container">
-              <input id="answer-{{key}}" type="radio" disabled {{#if choice}}checked{{/if}} />
-            </div>
-            {{~#if ../any_img~}}
-                <div class="poll-image result-image">
-                    <label for="answer-{{key}}" class="poll-image-label">
-                        {{#if img}}
-                          <img src="{{img}}" alt="{{img_alt}}"/>
-                        {{/if}}
-                    </label>
-                </div><div class="percentage-gauge-background"></div>
-            {{~/if~}}
-            <div class="percentage-gauge-container">
-              <div class="percentage-gauge" style="width:{{percent}}%;"></div>
-              <label class="poll-answer-label" for="answer-{{key}}">{{{answer}}}</label>
-            </div>
-            <div class="poll-percent-container">
-                <span class="poll-percent-display{{#if first}} poll-top-choice{{/if}}">{{percent}}%</span>
-            </div>
-        </li>
-    {{/each}}
-    </ul>
-    <input class="input-main" type="button" name="poll-submit" value="Submit" disabled>
-    <div class="poll-footnote">
-      {{interpolate (i18n_ngettext "Results gathered from {total} respondent." "Results gathered from {total} respondents." total) total=total}}
-    </div>
-    {{#if feedback}}
-        <hr />
-        <h3 class="poll-header">{{i18n "Feedback" }}</h3>
-        <div class="poll-feedback">
-            {{{feedback}}}
+    <div class="poll-results-wrapper" role="radiogroup" tabindex="0">
+        <h4 class="poll-header">{{i18n "Results" }}</h4>
+        <ul class="poll-answers-results poll-results {{~#if any_img}} has-images{{/if}}">
+        {{#each tally}}
+            <li class="poll-result">
+                <div class="poll-result-input-container">
+                  <input id="answer-{{key}}-{{../block_id}}" type="radio" disabled {{#if choice}}checked{{/if}} />
+                </div>
+                {{~#if ../any_img~}}
+                    <div class="poll-image result-image">
+                        <label for="answer-{{key}}-{{../block_id}}" class="poll-image-label">
+                            {{#if img}}
+                              <img src="{{img}}" alt="{{img_alt}}"/>
+                            {{/if}}
+                        </label>
+                    </div><div class="percentage-gauge-background"></div>
+                {{~/if~}}
+                <div class="percentage-gauge-container">
+                  <div class="percentage-gauge" style="width:{{percent}}%;"></div>
+                  <label class="poll-answer-label" for="answer-{{key}}-{{../block_id}}">{{{answer}}}</label>
+                </div>
+                <div class="poll-percent-container">
+                    <span class="poll-percent-display{{#if first}} poll-top-choice{{/if}}">{{percent}}%</span>
+                </div>
+            </li>
+        {{/each}}
+        </ul>
+        <input class="input-main" type="button" name="poll-submit" value="Submit" disabled>
+        <div class="poll-footnote">
+          {{interpolate (i18n_ngettext "Results gathered from {total} respondent." "Results gathered from {total} respondents." total) total=total}}
         </div>
-    {{/if}}
+        {{#if feedback}}
+            <hr />
+            <h3 class="poll-header">{{i18n "Feedback" }}</h3>
+            <div class="poll-feedback">
+                {{{feedback}}}
+            </div>
+        {{/if}}
+    </div>
 </script>

--- a/poll/public/handlebars/poll_studio.handlebars
+++ b/poll/public/handlebars/poll_studio.handlebars
@@ -1,4 +1,4 @@
-<script id="poll-form-component" type="text/html">
+<script class="poll-form-component" type="text/html">
 {{#each items}}
 <li class="field comp-setting-entry is-set poll-{{noun}}-studio-item">
     <div class="wrapper-comp-setting">

--- a/poll/public/handlebars/survey_results.handlebars
+++ b/poll/public/handlebars/survey_results.handlebars
@@ -1,40 +1,43 @@
-<script id="survey-results-template" type="text/html">
+<script class="survey-results-template" type="text/html">
     <h3 class="poll-header">{{block_name}}</h3>
-    <table class="survey-table poll-results">
-        <thead>
-            <tr>
-                <td></td>
-                {{#each answers}}
-                    <th class="survey-answer">{{{this}}}</th>
-                {{/each}}
-            </tr>
-        </thead>
-        {{#each tally}}
-            <tr class="survey-row">
-                <th class="survey-question">
-                    {{#if img}}
-                        <div class="poll-image-td">
-                            <img src="{{img}}" alt="img_alt"/>
-                        </div>
-                    {{/if}}
-                    {{{label}}}
-                </th>
-                {{#each answers}}
-                    <td class="survey-percentage survey-option{{#if choice}} survey-choice{{/if}}{{#if top}} poll-top-choice{{/if}}">{{percent}}%</td>
-                {{/each}}
-            </tr>
-        {{/each}}
-    </table>
-    <input class="input-main" type="button" name="poll-submit" value="Submit" disabled>
-    <div class="poll-footnote">
-        {{interpolate (i18n_ngettext "Results gathered from {total} respondent." "Results gathered from {total} respondents." total) total=total}}
-    </div>
-
-    {{#if feedback}}
-        <hr />
-        <h3 class="poll-header">{{i18n "Feedback" }}</h3>
-        <div class="poll-feedback">
-            {{{feedback}}}
+    <div class="poll-results-wrapper" tabindex="0">
+        <h4 class="poll-header">{{i18n "Results" }}</h4>
+        <table class="survey-table poll-results">
+            <thead>
+                <tr>
+                    <td></td>
+                    {{#each answers}}
+                        <th id="answer-{{key}}-{{../block_id}}" class="survey-answer">{{{label}}}</th>
+                    {{/each}}
+                </tr>
+            </thead>
+            {{#each tally}}
+                <tr class="survey-row">
+                    <th class="survey-question">
+                        {{#if img}}
+                            <div class="poll-image-td">
+                                <img src="{{img}}" alt="img_alt"/>
+                            </div>
+                        {{/if}}
+                        {{{label}}}
+                    </th>
+                    {{#each answers}}
+                        <td class="survey-percentage survey-option{{#if choice}} survey-choice{{/if}}{{#if top}} poll-top-choice{{/if}}" aria-labelledby="answer-{{key}}-{{../../block_id}}">{{percent}}%</td>
+                    {{/each}}
+                </tr>
+            {{/each}}
+        </table>
+        <input class="input-main" type="button" name="poll-submit" value="Submit" disabled>
+        <div class="poll-footnote">
+            {{interpolate (i18n_ngettext "Results gathered from {total} respondent." "Results gathered from {total} respondents." total) total=total}}
         </div>
-    {{/if}}
+
+        {{#if feedback}}
+            <hr />
+            <h3 class="poll-header">{{i18n "Feedback" }}</h3>
+            <div class="poll-feedback">
+                {{{feedback}}}
+            </div>
+        {{/if}}
+    </div>
 </script>

--- a/poll/public/html/poll.html
+++ b/poll/public/html/poll.html
@@ -5,29 +5,31 @@
     <h3 class="poll-header">{{ display_name }}</h3>
 
     <form>
-      <div class="poll-question-container">
-        {{ question|safe }}
-      </div>
-      <ul class="poll-answers">
-        {% for key, value in answers %}
-          <li class="poll-answer">
-            <div class="poll-input-container">
-              <input type="radio" name="choice" id="{{ url_name }}-answer-{{ key }}" value="{{ key }}"
-                  {% if choice == key %}checked{% endif %}/>
-            </div>
-            {% if any_img %}
-              <div class="poll-image">
-                <label for="{{ url_name }}-answer-{{ key }}" class="poll-image-label">
-                  {% if value.img %}
-                    <img src="{{ value.img }}"/>
-                  {% endif %}
-                </label>
+      <div role="group" aria-labelledby="{{ block_id }}-question">
+        <div id="{{ block_id }}-question" class="poll-question-container">
+          {{ question|safe }}
+        </div>
+        <ul class="poll-answers">
+          {% for key, value in answers %}
+            <li class="poll-answer">
+              <div class="poll-input-container">
+                <input type="radio" name="choice" id="{{ block_id }}-answer-{{ key }}" value="{{ key }}"
+                    {% if choice == key %}checked{% endif %}/>
               </div>
-            {% endif %}
-            <label class="poll-answer-text" for="{{ url_name }}-answer-{{ key }}">{{ value.label|safe }}</label>
-          </li>
-        {% endfor %}
-      </ul>
+              {% if any_img %}
+                <div class="poll-image">
+                  <label for="{{ block_id }}-answer-{{ key }}" class="poll-image-label">
+                    {% if value.img %}
+                      <img src="{{ value.img }}"/>
+                    {% endif %}
+                  </label>
+                </div>
+              {% endif %}
+              <label class="poll-answer-text" for="{{ block_id }}-answer-{{ key }}">{{ value.label|safe }}</label>
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
       <input class="input-main" type="button" name="poll-submit"
              value="{% if choice %}Resubmit{% else %}Submit{% endif %}" disabled/>
     </form>

--- a/poll/public/html/survey.html
+++ b/poll/public/html/survey.html
@@ -1,5 +1,6 @@
 {{ js_template|safe }}
-<div class="poll-block themed-xblock" data-private="{% if private_results %}1{% endif %}" data-can-vote="{% if can_vote %}1{% endif %}">
+<div class="poll-block themed-xblock" data-private="{% if private_results %}1{% endif %}"
+     data-can-vote="{% if can_vote %}1{% endif %}">
     <div class="poll-block-form-wrapper">
         <h3 class="poll-header">{{block_name}}</h3>
         <form>
@@ -13,7 +14,7 @@
                   </tr>
                 </thead>
             {% for key, question in questions %}
-                <tr class="survey-row">
+                <tr class="survey-row" role="group" aria-labelledby="{{block_id}}-{{key}}">
                     <th id="{{block_id}}-{{key}}" class="survey-question">
                         {% if question.img %}
                             <div class="poll-image-td">
@@ -28,9 +29,8 @@
                         <input type="radio"
                                name="{{key}}"
                                value="{{answer}}"{% if question.choice == answer %} checked{% endif %}
-                               aria-labelledby="{{block_id}}-{{key}} {{block_id}}-{{answer}}"
+                               aria-labelledby="{{block_id}}-{{answer}}"
                                />
-                        <span class="sr">{{label}}</span>
                       </label>
                     </td>
                 {% endfor %}

--- a/poll/public/js/poll.js
+++ b/poll/public/js/poll.js
@@ -37,7 +37,7 @@ function PollUtil (runtime, element, pollType) {
                 });
         });
 
-        this.resultsTemplate = Handlebars.compile($("#" + pollType + "-results-template", element).html());
+        this.resultsTemplate = Handlebars.compile($("." + pollType + "-results-template", element).html());
 
         this.viewResultsButton = $('.view-results-button', element);
         this.viewResultsButton.click(this.getResults);
@@ -204,12 +204,13 @@ function PollUtil (runtime, element, pollType) {
             data: JSON.stringify({}),
             success: function (data) {
                 $('div.poll-block', element).html(self.resultsTemplate(data));
+                $('.poll-results-wrapper').focus();
                 whenImagesLoaded(adjustGaugeBackground);
             }
         });
     };
 
-    this.enableSubmit = function () {
+    this.enableSubmit = function () {
         // Enable the submit button.
         self.submit.removeAttr("disabled");
         self.answers.unbind("change.enableSubmit");

--- a/poll/public/js/poll_edit.js
+++ b/poll/public/js/poll_edit.js
@@ -12,7 +12,7 @@ function PollEditUtil(runtime, element, pollType) {
 
     this.init = function () {
         // Set up the editing form for a Poll or Survey.
-        var temp = $('#poll-form-component', element).html();
+        var temp = $('.poll-form-component', element).html();
 
         // Set up gettext in case it isn't available in the client runtime:
         if (typeof gettext == "undefined") {

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-poll',
-    version='1.2',
+    version='1.2.1',
     description='An XBlock for polling users.',
     packages=[
         'poll',

--- a/tests/integration/test_functions.py
+++ b/tests/integration/test_functions.py
@@ -25,8 +25,6 @@ Tests a realistic, configured Poll to make sure that everything works as it
 should.
 """
 
-import itertools
-
 from .base_test import PollBaseTest
 
 
@@ -165,15 +163,15 @@ class TestSurveyFunctions(PollBaseTest):
         answers = self.browser.find_elements_by_css_selector('.survey-answer')
         question_ids = [question.get_attribute('id') for question in questions]
         answer_ids = [answer.get_attribute('id') for answer in answers]
-        id_pairs = [
-            "{question_id} {answer_id}".format(question_id=question_id, answer_id=answer_id)
-            for question_id, answer_id in itertools.product(question_ids, answer_ids)
-        ]
-        options = self.browser.find_elements_by_css_selector('.survey-option input')
-        self.assertEqual(len(options), len(id_pairs))
-        for option in options:
-            labelledby = option.get_attribute('aria-labelledby')
-            self.assertIn(labelledby, id_pairs)
+        rows = self.browser.find_elements_by_css_selector('.survey-row')
+        self.assertEqual(len(rows), len(questions))
+        for i, row in enumerate(rows):
+            self.assertEqual(row.get_attribute('role'), 'group')
+            self.assertEqual(row.get_attribute('aria-labelledby'), question_ids[i])
+            options = row.find_elements_by_css_selector('.survey-option input')
+            self.assertEqual(len(options), len(answers))
+            for j, option in enumerate(options):
+                self.assertEqual(option.get_attribute('aria-labelledby'), answer_ids[j])
 
     def fill_survey(self, assert_submit=False):
         """


### PR DESCRIPTION
This PR contains several minor accessibility fixes for problems described in [SOL-2059]( https://openedx.atlassian.net/browse/SOL-2059):

>
- The screenreader text that accompanies each radio button is unnecessary. The aria-labelledby completely takes care of the accessible name for the control. (Adds unnecessary verbosity for screen reader users who hear the SR text as well as the label, which are identical).
- There is a `<script>` element that has an ID attribute on it (`"survey-results-template"`) that gets repeated if there are more than two polls on a page. I doubt an ID attribute is needed on a `<script>` elements, but since this is being used as some sort of template, perhaps there's something I'm missing. (Causes automated test failures since all IDs must be unique).
- When the user submits their choices, the table of radiobuttons is replaced with the results of the survey. There is nothing to explicitly indicate to the user that this happened. (Must inform the user of this change of context).
- There is a View Results button. When it is pressed, focus is not managed. The next subsequent TAB key press moves the focus forward, not to the results of the survey. (non-visual users will not encounter the results unless they move backwards).

There is an additional problem mentioned in SOL-2059:

>
- Once a user Views the results, they cannot answer the poll again without reloading the page.

A solution for this problem was not implemented in this PR due to time constraints. The 'View Results' button is only visible to staff users, so this issue has lower priority.

SOL-2059 suggests making the "View Results" button persistent:

> Perhaps all of the last three issues can be solved by simply making the View Results button persistent.The value of the button could be toggled from View Results <-> Take survey. Upon pressing either button, the focus should be moved to the table (which will need a tabindex=-1)

The "View Results" button is only visible to staff users and the Poll xblock supports a setting to make the results private (and actually enforces private results when max allowed number of attempts is different from 1).
Making the button persistent and visible to all users would therefore cause complications and would require larger changes, so we decided to go with a simpler approach for now.

**JIRA tickets**: https://openedx.atlassian.net/browse/SOL-2059

**Dependencies**: None

**Sandbox URL**:

http://pr13430.sandbox.opencraft.hosting/ (installed version 03d4095b51d1126bc9c223c413d35673cf2a8bf5)

**Testing instructions**:

1. Add a poll block and a survey block to a unit (default settings are fine), or use the course prepared on the sandbox and skip this step. 
2. Visit the unit in the LMS as regular user, for example on the sandbox: http://pr13430.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/courseware/9fca584977d04885bc911ea76a9ef29e/525de9220872460da88fac33ae31b213/1?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%4035bedfa9bc9846c69486fe058377980b
3. Fill out the Poll.
4. Observe that the focus moves to the results list/table.
5. Repeat for the Survey block.
6. Log into LMS as staff user
7. Make sure focus moves to the results list/table when clicking the 'View Results' button.

**Author notes and concerns**:

After the user submits their answer, and results are not private, the poll/survey results are automatically shown. This PR adds a 'Results' header and automatically moves focus to the element that contains the results. Is this enough to inform non-visual users of change of context?

**Reviewers**
- [x] OpenCraft: @bdero 
- [x] a11y: @cptvitamin