### PR TITLE
[template] avoid potential invalid id attribute

### DIFF
--- a/poll/public/html/poll.html
+++ b/poll/public/html/poll.html
@@ -14,19 +14,19 @@
           {% for key, value in answers %}
             <div class="poll-answer">
               <div class="poll-input-container">
-                <input type="radio" name="choice" id="{{ block_id }}-answer-{{ key }}" value="{{ key }}"
+                <input type="radio" name="choice" id="poll-{{ block_id }}-answer-{{ key }}" value="{{ key }}"
                     {% if choice == key %}checked{% endif %}/>
               </div>
               {% if any_img %}
                 <div class="poll-image">
-                  <label for="{{ block_id }}-answer-{{ key }}" class="poll-image-label">
+                  <label for="poll-{{ block_id }}-answer-{{ key }}" class="poll-image-label">
                     {% if value.img %}
                       <img src="{{ value.img }}"/>
                     {% endif %}
                   </label>
                 </div>
               {% endif %}
-              <label class="poll-answer-text" for="{{ block_id }}-answer-{{ key }}">{{ value.label|safe }}</label>
+              <label class="poll-answer-text" for="poll-{{ block_id }}-answer-{{ key }}">{{ value.label|safe }}</label>
             </div>
           {% endfor %}
         </div>

--- a/poll/public/html/survey.html
+++ b/poll/public/html/survey.html
@@ -9,13 +9,13 @@
                   <tr>
                       <td></td>
                       {% for answer, label in answers %}
-                        <th id="{{block_id}}-{{answer}}" class="survey-answer">{{label}}</th>
+                        <th id="poll-{{block_id}}-{{answer}}" class="survey-answer">{{label}}</th>
                       {% endfor %}
                   </tr>
                 </thead>
             {% for key, question in questions %}
-                <tr class="survey-row" role="group" aria-labelledby="{{block_id}}-{{key}}">
-                    <th id="{{block_id}}-{{key}}" class="survey-question">
+                <tr class="survey-row" role="group" aria-labelledby="poll-{{block_id}}-{{key}}">
+                    <th id="poll-{{block_id}}-{{key}}" class="survey-question">
                         {% if question.img %}
                             <div class="poll-image-td">
                                 <img src="{{question.img}}" alt="{{question.img_alt|default_if_none:''}}"/>
@@ -29,7 +29,7 @@
                         <input type="radio"
                                name="{{key}}"
                                value="{{answer}}"{% if question.choice == answer %} checked{% endif %}
-                               aria-labelledby="{{block_id}}-{{answer}}"
+                               aria-labelledby="poll-{{block_id}}-{{answer}}"
                                />
                       </label>
                     </td>

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-poll',
-    version='1.2.4',
+    version='1.2.5',
     description='An XBlock for polling users.',
     packages=[
         'poll',


### PR DESCRIPTION
Hi folks! This PR introduces a small markup change fixing some invalid HTML in the poll template. The associated JIRA is [AC-711](https://openedx.atlassian.net/browse/AC-711).

Currently, the input radio button `id` attributes start with a numeric `block_id`, which is [illegal in CSS](https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier) as well as [HTML4](https://www.w3.org/TR/html401/types.html#type-name). While not technically illegal in HTML5, it still throws a DOM Exception 12 when queried with `querySelector`. We ran into this problem while running an accessibility audit with [edx/pa11ycrawler](https://github.com/edx/pa11ycrawler). To get around this, I prefixed the `id` attribute with the string `poll-`.

Aside from tests passing, is there anything else I need to do to get this merged?