### PR TITLE
compile translations during xblock install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,33 @@
 """Setup for poll XBlock."""
 
 import os
+import subprocess
 from setuptools import setup
+from setuptools.command.install import install as _install
+
+
+class XBlockInstall(_install):
+    """Custom XBlock install command."""
+
+    def run(self):
+        _install.run(self)
+        self.compile_translations()
+
+    def compile_translations(self):
+        """
+        Compiles textual translations files(.po) to binary(.mo) files.
+        """
+        self.announce('Compiling translations')
+        try:
+            for dirname, _, files in os.walk(os.path.join('poll', 'translations')):
+                for fname in files:
+                    if os.path.splitext(fname)[1] == '.po':
+                        po_path = os.path.join(dirname, fname)
+                        mo_path = os.path.splitext(po_path)[0] + '.mo'
+                        self.announce('Compiling translation at %s' % po_path)
+                        subprocess.check_call(['msgfmt', po_path, '-o', mo_path], cwd=self.install_lib)
+        except Exception as ex:
+            self.announce('Translations compilation failed: %s' % ex.message)
 
 
 def package_data(pkg, roots):
@@ -62,4 +88,7 @@ setup(
         ]
     },
     package_data=package_data("poll", ["static", "public", "translations"]),
+    cmdclass={
+        'install': XBlockInstall,
+    },
 )


### PR DESCRIPTION
@e-kolpakov  This PR has added post install hook to installation step which compiles translation. Downside of this approach is pip uninstall does not remove those compiled translation(.mo) when package is removed. I was not able to find a post uninstall hook either for setuptools or distutils.