### PR TITLE
Tag HTML strings for translation

### DIFF
--- a/poll/public/html/poll.html
+++ b/poll/public/html/poll.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {{ js_template|safe }}
 <div class="poll-block themed-xblock" data-private="{% if private_results %}1{% endif %}"
      data-can-vote="{% if can_vote %}1{% endif %}">
@@ -31,23 +32,24 @@
           {% endfor %}
         </div>
       </fieldset>
-      <input class="input-main" type="button" name="poll-submit" value="Submit" disabled/>
+      <input class="input-main" type="button" name="poll-submit" value="{% trans 'Submit' %}" disabled/>
     </form>
 
     <div class="poll-voting-thanks
         {% if not choice or can_vote %}poll-hidden{% endif %}">
-      <span>Thank you.</span>
+      <span>{% trans 'Thank you.' %}</span>
     </div>
 
     <div class="poll-submissions-count poll-hidden">
-      You have used <span class="poll-current-count">{{ submissions_count }}</span>
-      out of <span class="poll-max-submissions">{{ max_submissions }}</span> submissions.
+      {% blocktrans with submissions_count_s='<span class="poll-current-count">{{ submissions_count }}</span>' max_submissions_s='<span class="poll-max-submissions">{{ max_submissions }}</span>' %}
+        You have used {{ submissions_count_s }} out of {{ max_submissions_s }} submissions.
+      {% endblocktrans %}
     </div>
 
     {% if feedback %}
       <div class="poll-feedback-container{% if not choice %} poll-hidden{% endif %}">
         <hr/>
-        <h3 class="poll-header">Feedback</h3>
+        <h3 class="poll-header">{% trans 'Feedback' %}</h3>
 
         <div class="poll-feedback">
           {{ feedback|safe }}
@@ -57,7 +59,7 @@
 
     {% if can_view_private_results %}
       <div class="view-results-button-wrapper">
-        <button class="view-results-button">View results</button>
+        <button class="view-results-button">{% trans 'View results' %}</button>
       </div>
     {% endif %}
 

--- a/poll/public/html/poll_edit.html
+++ b/poll/public/html/poll_edit.html
@@ -1,75 +1,88 @@
+{% load i18n %}
 {{js_template|safe}}
 <div class="wrapper-comp-settings is-active editor-with-buttons" id="settings-tab">
     <form id="poll-form">
     <ul class="list-input settings-list" id="poll-line-items">
         <li class="field comp-setting-entry is-set">
             <div class="wrapper-comp-setting">
-                <label class="label setting-label poll-setting-label" for="poll-display-name">Display Name</label>
+                <label class="label setting-label poll-setting-label" for="poll-display-name">{% trans 'Display Name' %}</label>
                 <!-- In the case of surveys, this field will actually be used for block_name. -->
                 <input class="input setting-input" name="display_name" id="poll-display-name" value="{{ display_name }}" type="text" />
             </div>
         </li>
         {% if not multiquestion %}
             <li class="field comp-setting-entry is-set">
-              <h2><label for="poll-question-editor">Question/Prompt</label></h2>
-              <a href="//daringfireball.net/projects/markdown/syntax" target="_blank">Markdown Syntax</a> is supported.
-              <div id="poll-question-editor-container">
-                <textarea class="input setting-input" name="question" id="poll-question-editor"
-                          aria-describedby="poll-question-editor-help">{{question}}</textarea>
-              </div>
-              <span class="tip setting-help" id="poll-question-editor-help">Enter the prompt for the user.</span>
+                <h2><label for="poll-question-editor">{% trans 'Question/Prompt' %}</label></h2>
+                {% blocktrans with link_start='<a href="//daringfireball.net/projects/markdown/syntax" target="_blank">' link_end='</a>' %}
+                    {{link_start}}Markdown Syntax{{link_end}} is supported.
+                {% endblocktrans %}
+                <div id="poll-question-editor-container">
+                    <textarea class="input setting-input" name="question" id="poll-question-editor"
+                              aria-describedby="poll-question-editor-help">{{question}}</textarea>
+                </div>
+                <span class="tip setting-help" id="poll-question-editor-help">{% trans 'Enter the prompt for the user.' %}</span>
             </li>
         {% endif %}
         <li class="field comp-setting-entry is-set">
-           <h2><label for="poll-feedback-editor">Feedback</label></h2>
-           <a href="//daringfireball.net/projects/markdown/syntax" target="_blank">Markdown Syntax</a> is supported.
-           <div id="poll-feedback-editor-container">
-             <textarea class="input setting-input" name="feedback" id="poll-feedback-editor"
-                       aria-describedby="poll-feedback-editor-help">{{feedback}}</textarea>
-           </div>
+            <h2><label for="poll-feedback-editor">{% trans 'Feedback' %}</label></h2>
+            {% blocktrans with link_start='<a href="//daringfireball.net/projects/markdown/syntax" target="_blank">' link_end='</a>' %}
+                {{link_start}}Markdown Syntax{{link_end}} is supported.
+            {% endblocktrans %}
+            <div id="poll-feedback-editor-container">
+                <textarea class="input setting-input" name="feedback" id="poll-feedback-editor"
+                          aria-describedby="poll-feedback-editor-help">{{feedback}}</textarea>
+            </div>
             <span class="tip setting-help" id="poll-feedback-editor-help">
-                This text will be displayed for the user as some extra feedback after they have
-                submitted their response to the poll.
+                {% blocktrans %}
+                    This text will be displayed for the user as some extra feedback after they have
+                    submitted their response to the poll.
+                {% endblocktrans %}
             </span>
         </li>
         <li class="field comp-setting-entry is-set">
             <div class="wrapper-comp-setting">
-                <label class="label setting-label poll-setting-label" for="poll-private-results">Private Results</label>
+                <label class="label setting-label poll-setting-label" for="poll-private-results">{% trans 'Private Results' %}</label>
                 <select id="poll-private-results" class="input setting-input" name="private_results"
                         aria-describedby="poll-private-results-help">
                     <!-- So far as I can see, there's not a proper style for checkboxes. LTI module does it this way. -->
-                    <option value="true" {% if private_results %} selected{% endif %}>True</option>
-                    <option value="false" {% if not private_results %} selected{% endif %}>False</option>
+                    <option value="true" {% if private_results %} selected{% endif %}>{% trans 'True' %}</option>
+                    <option value="false" {% if not private_results %} selected{% endif %}>{% trans 'False' %}</option>
                 </select>
             </div>
             <span class="tip setting-help" id="poll-private-results-help">
-                If this is set to True, don't display results of the poll to the user.
+                {% trans "If this is set to True, don't display results of the poll to the user." %}
             </span>
         </li>
         <li class="field comp-setting-entry is-set">
             <div class="wrapper-comp-setting">
-                <label class="label setting-label poll-setting-label" for="poll-max-submissions">Maximum Submissions</label>
+                <label class="label setting-label poll-setting-label" for="poll-max-submissions">{% trans 'Maximum Submissions' %}</label>
                 <input id="poll-max-submissions" type="number" min="0" step="1" value="{{ max_submissions }}"
                        aria-describedby="poll-max-submissions-help"/>
             </div>
             <span class="tip setting-help" id="poll-max-submissions-help">
-                Maximum number of times a user may submit a poll. <strong>Setting this to a value other than 1 will imply that
-                'Private Results' should be true.</strong> Setting it to 0 will allow infinite resubmissions.
+                {% blocktrans with bold_start='<strong>' bold_end='</strong>' %}
+                    Maximum number of times a user may submit a poll. {{bold_start}}Setting this to a value other than 1 will imply that
+                    'Private Results' should be true.{{bold_end}} Setting it to 0 will allow infinite resubmissions.
+                {% endblocktrans %}
             </span>
         </li>
         <li class="field comp-setting-entry is-set">
             <p>
-                <strong>Notes:</strong>
-                If you change an answer's text, all students who voted for that choice will have their votes updated to
-                the new text. You'll want to avoid changing an answer from something like 'True' to 'False', accordingly.
-                If you delete an answer, any votes for that answer will also be deleted. Students whose choices are deleted
-                may vote again, but will not lose course progress.
+                <strong>{% trans 'Notes:' %}</strong>
+                {% blocktrans %}
+                    If you change an answer's text, all students who voted for that choice will have their votes updated to
+                    the new text. You'll want to avoid changing an answer from something like 'True' to 'False', accordingly.
+                    If you delete an answer, any votes for that answer will also be deleted. Students whose choices are deleted
+                    may vote again, but will not lose course progress.
+                {% endblocktrans %}
             </p>
             {%  if multiquestion %}
                 <p>
-                    Questions must be similarly cared for. If a question's text is changed, any votes for that question will remain.
-                    If a question is deleted, any student who previously took the survey will be permitted to retake it, but will not
-                    lose course progress.
+                    {% blocktrans %}
+                        Questions must be similarly cared for. If a question's text is changed, any votes for that question will remain.
+                        If a question is deleted, any student who previously took the survey will be permitted to retake it, but will not
+                        lose course progress.
+                    {% endblocktrans %}
                 </p>
             {% endif %}
         </li>
@@ -81,18 +94,18 @@
     <div class="xblock-actions">
         <ul>
             <li class="action-item" id="poll-add-answer">
-                <a href="#" class="button action-button" class="poll-add-item-link" onclick="return false;">Add Answer</a>
+                <a href="#" class="button action-button" class="poll-add-item-link" onclick="return false;">{% trans 'Add Answer' %}</a>
             </li>
             {% if multiquestion %}
                 <li class="action-item" id="poll-add-question">
-                    <a href="#" class="button action-button" class="poll-add-item-link" onclick="return false;">Add Question</a>
+                    <a href="#" class="button action-button" class="poll-add-item-link" onclick="return false;">{% trans 'Add Question' %}</a>
                 </li>
             {% endif %}
             <li class="action-item">
-                <input id="poll-submit-options" type="submit" class="button action-primary save-button" value="Save" onclick="return false;" />
+                <input id="poll-submit-options" type="submit" class="button action-primary save-button" value="{% trans 'Save' %}" onclick="return false;" />
             </li>
             <li class="action-item">
-                <a href="#" class="button cancel-button">Cancel</a>
+                <a href="#" class="button cancel-button">{% trans 'Cancel' %}</a>
             </li>
         </ul>
     </div>

--- a/poll/public/html/survey.html
+++ b/poll/public/html/survey.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {{ js_template|safe }}
 <div class="poll-block themed-xblock" data-private="{% if private_results %}1{% endif %}"
      data-can-vote="{% if can_vote %}1{% endif %}">
@@ -49,17 +50,18 @@
                 </tr>
             {% endfor %}
             </table>
-            <input class="input-main" type="button" name="poll-submit" value="Submit" disabled />
+            <input class="input-main" type="button" name="poll-submit" value="{% trans 'Submit' %}" disabled />
         </form>
-        <div class="poll-voting-thanks{% if not choices or can_vote %} poll-hidden{% endif %}"><span>Thank you.</span></div>
+        <div class="poll-voting-thanks{% if not choices or can_vote %} poll-hidden{% endif %}"><span>{% trans 'Thank you.' %}</span></div>
         <div class="poll-submissions-count poll-hidden">
-            You have used <span class="poll-current-count">{{ submissions_count }}</span>
-            out of <span class="poll-max-submissions">{{ max_submissions }}</span> submissions.
+            {% blocktrans with submissions_count_s='<span class="poll-current-count">{{ submissions_count }}</span>' max_submissions_s='<span class="poll-max-submissions">{{ max_submissions }}</span>' %}
+                You have used {{ submissions_count_s }} out of {{ max_submissions_s }} submissions.
+            {% endblocktrans %}
         </div>
         {% if feedback %}
             <div class="poll-feedback-container{% if not choices %} poll-hidden{% endif %}">
                 <hr />
-                <h3 class="poll-header">Feedback</h3>
+                <h3 class="poll-header">{% trans 'Feedback' %}</h3>
                 <div class="poll-feedback">
                     {{feedback|safe}}
                 </div>
@@ -67,7 +69,7 @@
         {% endif %}
 
         {% if can_view_private_results %}
-            <div class="view-results-button-wrapper"><button class="view-results-button">View results</button></div>
+            <div class="view-results-button-wrapper"><button class="view-results-button">{% trans 'View results' %}</button></div>
         {% endif %}
     </div>
 </div>

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-poll',
-    version='1.3.3',
+    version='1.3.4',
     description='An XBlock for polling users.',
     packages=[
         'poll',


### PR DESCRIPTION
Hi I'm a developer on the Stanford team that runs a few OpenEdX instances and we are using this xblock in Vietnamese. I noticed the HTML strings weren't tagged for translation, so I've gone ahead and done it. I didn't touch the .po files since it's not clear from documentation how its done (custom handlebars strings, are these manually stitched together into the final text.po? Or some fiddling with config.yml and i18n_tools?)

@e-kolpakov @bradenmacdonald 
Not sure if I tagged the right people, apologies in advance.