### PR TITLE
Enable webview for Poll & Survey blocks

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -360,6 +360,7 @@ class PollBlock(PollBase):
         else:
             return None
 
+    @XBlock.supports("multi_device")  # Mark as mobile-friendly
     def student_view(self, context=None):
         """
         The primary view of the PollBlock, shown to students
@@ -582,6 +583,7 @@ class SurveyBlock(PollBase):
     choices = Dict(help="The user's answers", scope=Scope.user_state)
     event_namespace = 'xblock.survey'
 
+    @XBlock.supports("multi_device")  # Mark as mobile-friendly
     def student_view(self, context=None):
         """
         The primary view of the SurveyBlock, shown to students

--- a/tests/integration/test_private_results.py
+++ b/tests/integration/test_private_results.py
@@ -78,24 +78,6 @@ class TestPrivateResults(PollBaseTest):
 
     @unpack
     @data(*scenarios)
-    def test_submit_button(self, page_name, names):
-        self.go_to_page(page_name)
-        submit = self.get_submit()
-        self.assertIn('Submit', submit.get_attribute('outerHTML'))
-
-        self.make_selections(names)
-        submit.click()
-        self.wait_until_clickable(self.browser.find_element_by_css_selector('.poll-voting-thanks'))
-
-        self.assertIn('Resubmit', submit.get_attribute('outerHTML'), 'Resubmit')
-
-        # This should persist on page reload.
-        self.go_to_page(page_name)
-        submit = self.get_submit()
-        self.assertIn('Resubmit', submit.get_attribute('outerHTML'), 'Resubmit')
-
-    @unpack
-    @data(*scenarios)
     def test_feedback_display(self, page_name, names):
         self.go_to_page(page_name)
         self.assertFalse(self.browser.find_element_by_css_selector('.poll-feedback').is_displayed())


### PR DESCRIPTION
This enables mobile view. Over time we will work to improve the responsiveness of each webview version.

**Testing**:

1. Add Survey and Poll blocks to your course.
1. Publish the unit.
1. Without this patch: verify that the course blocks API reports `"student_view_multi_device": false` for both blocks.
1. With this patch: verify that the course blocks API reports `"student_view_multi_device": true` for both blocks.

Example of the course blocks API url is:

http://lms.mcka.local/api/courses/v1/blocks/?course_id=my/course/key&all_blocks=true&depth=all&requested_fields=student_view_multi_device&block_types_filter=poll,survey

**NOTE 1**: Course block API responses are cached, so you may see stale responses. One simple way to clear and rebuild the cache is to publish a random unit in your course.

**NOTE 2**: For some reason I can't get the course API to work with the DemoX course, it keeps errorring out for me. Please use a course other than the default DemoX to test this.

**Reviewers**:

- [ ] @e-kolpakov