### PR TITLE
Hide element outline after poll is submitted

### DIFF
--- a/poll/public/css/poll.css
+++ b/poll/public/css/poll.css
@@ -64,6 +64,10 @@
     padding-left: 1em;
 }
 
+.poll-results-wrapper:focus {
+    outline: none;
+}
+
 ul.poll-answers-results {
     list-style-type: none !important;
 }

--- a/poll/public/js/poll.js
+++ b/poll/public/js/poll.js
@@ -211,7 +211,7 @@ function PollUtil (runtime, element, pollType) {
             data: JSON.stringify({}),
             success: function (data) {
                 $('div.poll-block', element).html(self.resultsTemplate(data));
-                $('.poll-results-wrapper').focus();
+                $('.poll-results-wrapper', element).focus();
                 whenImagesLoaded(adjustGaugeBackground);
             }
         });


### PR DESCRIPTION
Hides element outline after poll is submitted; fixes JS bug where focus may be given to another poll block on the same page

**JIRA tickets**: [OC-2980](https://tasks.opencraft.com/browse/OC-2980) [MCKIN-5301](https://edx-wiki.atlassian.net/browse/MCKIN-5301)

**Discussions**: @bradenmacdonald identified an additional bug where the the selector to find the element to apply focus to was too broad.

**Dependencies**: None

**Merge deadline**: ASAP

**Testing instructions**:

1. Set up a unit with a poll xblock 
* Submit an answer
* See that no outline surrounds the block's HTML

**Reviewers**
- [ ] @bradenmacdonald 
