### PR TITLE
CSV export for LMS

### DIFF
--- a/poll/public/css/poll.css
+++ b/poll/public/css/poll.css
@@ -274,7 +274,8 @@ th.survey-answer {
     font-weight: bold;
 }
 
-.view-results-button-wrapper {
+.view-results-button-wrapper, .export-results-button-wrapper {
+    margin-bottom: 5px;
     text-align: right;
     cursor: pointer;
 }

--- a/poll/public/html/poll.html
+++ b/poll/public/html/poll.html
@@ -57,11 +57,22 @@
       </div>
     {% endif %}
 
-    {% if can_view_private_results %}
+
+  </div>
+      {% if can_view_private_results %}
       <div class="view-results-button-wrapper">
         <button class="view-results-button">{% trans 'View results' %}</button>
       </div>
     {% endif %}
-
-  </div>
 </div>
+{% if can_view_private_results %}
+  {% if not studio_edit %}
+    <div class="export-results-button-wrapper">
+      <button class="export-results-button">Export results to CSV</button>
+      <button disabled class="download-results-button">Download CSV</button>
+      <p class="error-message poll-hidden"></p>
+    </div>
+  {% else %}
+    <p>Student data and results CSV available for download in the LMS.</p>
+  {% endif %}
+{% endif %}

--- a/poll/public/html/survey.html
+++ b/poll/public/html/survey.html
@@ -69,7 +69,20 @@
         {% endif %}
 
         {% if can_view_private_results %}
-            <div class="view-results-button-wrapper"><button class="view-results-button">{% trans 'View results' %}</button></div>
+            <div class="view-results-button-wrapper">
+                <button class="view-results-button">{% trans 'View results' %}</button>
+            </div>
         {% endif %}
     </div>
 </div>
+{% if can_view_private_results %}
+  {% if not studio_edit %}
+    <div class="export-results-button-wrapper">
+      <button class="export-results-button">Export results to CSV</button>
+      <button disabled class="download-results-button">Download CSV</button>
+      <p class="error-message poll-hidden"></p>
+    </div>
+  {% else %}
+    <p>Student data and results CSV available for download in the LMS.</p>
+  {% endif %}
+{% endif %}

--- a/poll/public/js/poll.js
+++ b/poll/public/js/poll.js
@@ -2,14 +2,17 @@
 
 function PollUtil (runtime, element, pollType) {
     var self = this;
+    var exportStatus = {};
 
     this.init = function() {
         // Initialization function used for both Poll Types
         this.voteUrl = runtime.handlerUrl(element, 'vote');
         this.tallyURL = runtime.handlerUrl(element, 'get_results');
+        this.csv_url= runtime.handlerUrl(element, 'csv_export');
         this.votedUrl = runtime.handlerUrl(element, 'student_voted');
         this.submit = $('input[type=button]', element);
         this.answers = $('input[type=radio]', element);
+        this.errorMessage = $('.error-message', element);
 
         // Set up gettext in case it isn't available in the client runtime:
         if (typeof gettext == "undefined") {
@@ -50,6 +53,12 @@ function PollUtil (runtime, element, pollType) {
 
         this.viewResultsButton = $('.view-results-button', element);
         this.viewResultsButton.click(this.getResults);
+
+        this.exportResultsButton = $('.export-results-button', element);
+        this.exportResultsButton.click(this.exportCsv);
+
+        this.downloadResultsButton = $('.download-results-button', element);
+        this.downloadResultsButton.click(this.downloadCsv);
 
         return this.shouldDisplayResults();
     };
@@ -183,6 +192,46 @@ function PollUtil (runtime, element, pollType) {
         }
         // Used if results are not private, to show the user how other students voted.
         self.getResults();
+    };
+
+    function getStatus() {
+        $.ajax({
+            type: 'POST',
+            url: runtime.handlerUrl(element, 'get_export_status'),
+            data: '{}',
+            success: updateStatus,
+            dataType: 'json'
+        });
+    }
+
+    function updateStatus(newStatus) {
+        var statusChanged = ! _.isEqual(newStatus, exportStatus);
+        exportStatus = newStatus;
+        if (exportStatus.export_pending) {
+            // Keep polling for status updates when an export is running.
+            setTimeout(getStatus, 1000);
+        }
+        if (statusChanged) {
+            if (newStatus.last_export_result.error) {
+                self.errorMessage.text(error);
+                self.errorMessage.show();
+            } else {
+                self.downloadResultsButton.attr('disabled', false);
+                self.errorMessage.hide()
+            }
+        }
+    }
+
+    this.exportCsv = function() {
+        $.ajax({
+            type: "POST",
+            url: self.csv_url,
+            data: JSON.stringify({}),
+            success: updateStatus
+        });
+    };
+    this.downloadCsv = function() {
+        window.location = exportStatus.download_url;
     };
 
     this.getResults = function () {

--- a/poll/tasks.py
+++ b/poll/tasks.py
@@ -1,0 +1,33 @@
+import time
+
+from celery.decorators import task  # pylint: disable=import-error
+
+from lms.djangoapps.instructor_task.models import ReportStore  # pylint: disable=import-error
+from opaque_keys.edx.keys import CourseKey, UsageKey  # pylint: disable=import-error
+from xmodule.modulestore.django import modulestore  # pylint: disable=import-error
+
+
+@task()
+def export_csv_data(block_id, course_id):
+    """
+    Exports student answers to all supported questions to a CSV file.
+    """
+
+    src_block = modulestore().get_item(UsageKey.from_string(block_id))
+
+    start_timestamp = time.time()
+    course_key = CourseKey.from_string(course_id)
+
+    filename = src_block.get_filename()
+
+    report_store = ReportStore.from_config(config_name='GRADES_DOWNLOAD')
+    report_store.store_rows(course_key, filename, src_block.prepare_data())
+
+    generation_time_s = time.time() - start_timestamp
+
+    return {
+        "error": None,
+        "report_filename": filename,
+        "start_timestamp": start_timestamp,
+        "generation_time_s": generation_time_s,
+    }

--- a/tests/unit/test_xblock_poll.py
+++ b/tests/unit/test_xblock_poll.py
@@ -1,5 +1,6 @@
 import unittest
 import json
+
 from xblock.field_data import DictFieldData
 
 from poll.poll import PollBlock, SurveyBlock


### PR DESCRIPTION
Adds CSV export + download buttons to the Survey and Poll XBlocks.

**JIRA tickets**: [OC-2981](https://tasks.opencraft.com/browse/OC-2981) [MCKIN-5433](https://edx-wiki.atlassian.net/browse/MCKIN-5433)

**Testing instructions**:

1. In a course with a survey or poll xblock,
1. Click on the export button to queue a CSV export
1. Click the now-active download button to download the CSV
1. Notice the difference in formatting between survey and poll output

Screenshot:

<img width="484" alt="screen shot 2017-09-15 at 4 10 24 pm" src="https://user-images.githubusercontent.com/1826172/30486330-79003714-9a30-11e7-8405-1a9279788b27.png">

**Reviewers**
- [ ] @cgopalan  
- [ ] @bradenmacdonald 
