### PR TITLE
Mark Poll and Survey XBlocks as Mobile friendly

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -396,6 +396,7 @@ class PollBlock(PollBase):
 
         return None
 
+    @XBlock.supports("multi_device")  # Mark as mobile-friendly
     def student_view(self, context=None):
         """
         The primary view of the PollBlock, shown to students
@@ -655,6 +656,7 @@ class SurveyBlock(PollBase):
     choices = Dict(help=_("The user's answers"), scope=Scope.user_state)
     event_namespace = 'xblock.survey'
 
+    @XBlock.supports("multi_device")  # Mark as mobile-friendly
     def student_view(self, context=None):
         """
         The primary view of the SurveyBlock, shown to students


### PR DESCRIPTION
Given the responsiveness improvements that have been added lately and the need to use the mobile webview, we are now ready to permanently mark this as mobile friendly.

Previously introduced into a branch via #29 but never merged to `master`.