### PR TITLE
Fix FailingEnforceTypeWarning in SurveyBlock

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -770,9 +770,9 @@ class SurveyBlock(PollBase, CSVExportMixin):
     # but either way we want it to say 'Poll' by default on the page.
     block_name = String(default=_('Poll'))
     answers = List(
-        default=(
+        default=[
             ('Y', _('Yes')), ('N', _('No')),
-            ('M', _('Maybe'))),
+            ('M', _('Maybe'))],
         scope=Scope.settings, help=_("Answer choices for this Survey")
     )
     questions = List(


### PR DESCRIPTION
Fix the warning described in [TE-2583](https://openedx.atlassian.net/browse/TE-2583):

```
WARNING 7632 [py.warnings] fields.py:455 - /edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/poll/poll.py:607: FailingEnforceTypeWarning: The value (('Y', 'Yes'), ('N', 'No'), ('M', 'Maybe')) could not be enforced (TypeError: Value stored in a List must be None or a list, found <type 'tuple'>)
  scope=Scope.settings, help=_("Answer choices for this Survey")
```

As far as I can tell, this change shouldn't have any effect beyond satisfying code in the `xblock` package that the correct type of value was provided.