### PR TITLE
Fix frequent warning.

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -771,8 +771,10 @@ class SurveyBlock(PollBase, CSVExportMixin):
     block_name = String(default=_('Poll'))
     answers = List(
         default=[
-            ('Y', _('Yes')), ('N', _('No')),
-            ('M', _('Maybe'))],
+            ('Y', _('Yes')),
+            ('N', _('No')),
+            ('M', _('Maybe'))
+        ],
         scope=Scope.settings, help=_("Answer choices for this Survey")
     )
     questions = List(

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-poll',
-    version='1.5.0',
+    version='1.5.1',
     description='An XBlock for polling users.',
     packages=[
         'poll',


### PR DESCRIPTION
- Change default value from tuple to list.
- Bump version to 1.5.1.

Fixes this warning message, which happens on every server restart:
```
2018-06-06 09:00:32,220 WARNING 2477 [py.warnings] fields.py:455
 - /edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/poll/poll.py:607: 
FailingEnforceTypeWarning: The value (('Y', 'Yes'), 
('N', 'No'), ('M', 'Maybe')) could not be enforced 
(TypeError: Value stored in a List must be None or a list, found <type 'tuple'>)
  scope=Scope.settings, help=_("Answer choices for this Survey")
```