### PR TITLE
version bump to 1dc36a8 (update translations)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-poll',
-    version='1.6.0',
+    version='1.6.1',
     description='An XBlock for polling users.',
     packages=[
         'poll',


### PR DESCRIPTION
version bump to [1dc36a8](https://github.com/open-craft/xblock-poll/commit/1dc36a827a32fb651e8de97a9e539e70ce84b38f) (update translations)