### PR TITLE
MCKIN-8799 Download button enabled only when final download url is ready

### DIFF
--- a/poll/public/js/poll.js
+++ b/poll/public/js/poll.js
@@ -178,13 +178,15 @@ function PollUtil (runtime, element, pollType) {
             // Keep polling for status updates when an export is running.
             setTimeout(getStatus, 1000);
         }
-        if (statusChanged) {
-            if (newStatus.last_export_result.error) {
-                self.errorMessage.text(error);
-                self.errorMessage.show();
-            } else {
-                self.downloadResultsButton.attr('disabled', false);
-                self.errorMessage.hide()
+        else {
+            if (statusChanged) {
+                if (newStatus.last_export_result.error) {
+                    self.errorMessage.text(error);
+                    self.errorMessage.show();
+                } else {
+                    self.downloadResultsButton.attr('disabled', false);
+                    self.errorMessage.hide()
+                }
             }
         }
     }

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-poll',
-    version='1.6.1',
+    version='1.6.2',
     description='An XBlock for polling users.',
     packages=[
         'poll',


### PR DESCRIPTION
Jira ticket: https://edx-wiki.atlassian.net/browse/MCKIN-8799

When downloading polling data, I follow the steps below:

1. Click view results
2. Click export data
3. Once the data is ready for download, download
4. The exported CSV of data is always the data from the last pull, not from today's date.
5. I refresh the page, follow steps 1 - 3, and then it downloads the most recent data. So I am following the process twice to ensure that this is the most accurate, up-to-date data.