### PR TITLE
[BB-993] Fix a bug in report generation where a survey response has no choices key

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -810,7 +810,9 @@ class PollBlock(PollBase, CSVExportMixin):
                 # End the iterator here
                 return
 
-            choice = user_state.state['choice']  # {u'submissions_count': 1, u'choice': u'R'}
+            choice = user_state.state.get('choice')  # {u'submissions_count': 1, u'choice': u'R'}
+            if choice is None:
+                continue
             report = {
                 self.ugettext('Question'): self.question,
                 self.ugettext('Answer'): answers_dict[choice]['label'],

--- a/poll/poll.py
+++ b/poll/poll.py
@@ -1298,7 +1298,7 @@ class SurveyBlock(PollBase, CSVExportMixin):
         count = 0
         for user_state in user_state_iterator:
             # user_state.state={'submissions_count': 1, 'choices': {u'enjoy': u'Y', u'recommend': u'N', u'learn': u'M'}}
-            choices = user_state.state.get('choices', {})
+            choices = user_state.state.get('choices') or {}
             for question_id, answer_id in choices.items():
 
                 if limit_responses is not None and count >= limit_responses:

--- a/poll/poll.py
+++ b/poll/poll.py
@@ -1296,7 +1296,7 @@ class SurveyBlock(PollBase, CSVExportMixin):
         count = 0
         for user_state in user_state_iterator:
             # user_state.state={'submissions_count': 1, 'choices': {u'enjoy': u'Y', u'recommend': u'N', u'learn': u'M'}}
-            choices = user_state.state['choices']
+            choices = user_state.state.get('choices', {})
             for question_id, answer_id in choices.items():
 
                 if limit_responses is not None and count >= limit_responses:

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-poll',
-    version='1.8.0',
+    version='1.8.1',
     description='An XBlock for polling users.',
     packages=[
         'poll',

--- a/tests/unit/test_xblock_poll.py
+++ b/tests/unit/test_xblock_poll.py
@@ -212,6 +212,12 @@ class TestSurveyBlock(unittest.TestCase):
                     'choices': {'enjoy': 'Y', 'recommend': 'N', 'learn': 'M'}
                 }
             ),
+            Mock(
+                username='audit',
+                state={
+                    'submissions_count': 1,
+                }
+            ),
         )
 
     def test_generate_report_data_dont_limit_responses(self):

--- a/tests/unit/test_xblock_poll.py
+++ b/tests/unit/test_xblock_poll.py
@@ -78,6 +78,7 @@ class TestPollBlock(unittest.TestCase):
             Mock(username='staff', state={'submissions_count': 1, 'choice': 'B'}),
             Mock(username='honor', state={'submissions_count': 1, 'choice': 'O'}),
             Mock(username='audit', state={'submissions_count': 1}),
+            Mock(username='student', state={'submissions_count': 1, 'choice': None}),
         )
 
     def test_generate_report_data_dont_limit_responses(self):
@@ -93,6 +94,7 @@ class TestPollBlock(unittest.TestCase):
                                   'Answer': 'Red',
                                   'Submissions count': 1}))
         self.assertNotIn('audit', [username for username, _ in report_data])
+        self.assertNotIn('student', [username for username, _ in report_data])
 
     def test_generate_report_data_limit_responses(self):
         """
@@ -220,6 +222,13 @@ class TestSurveyBlock(unittest.TestCase):
                     'submissions_count': 1,
                 }
             ),
+            Mock(
+                username='student',
+                state={
+                    'submissions_count': 1,
+                    'choices': None,
+                }
+            ),
         )
 
     def test_generate_report_data_dont_limit_responses(self):
@@ -239,6 +248,7 @@ class TestSurveyBlock(unittest.TestCase):
             set([data['Answer'] for _, data in report_data[:4]])
         )
         self.assertNotIn('audit', [username for username, _ in report_data])
+        self.assertNotIn('student', [username for username, _ in report_data])
 
     def test_generate_report_data_limit_responses(self):
         """

--- a/tests/unit/test_xblock_poll.py
+++ b/tests/unit/test_xblock_poll.py
@@ -77,6 +77,7 @@ class TestPollBlock(unittest.TestCase):
             Mock(username='verified', state={'submissions_count': 1, 'choice': 'G'}),
             Mock(username='staff', state={'submissions_count': 1, 'choice': 'B'}),
             Mock(username='honor', state={'submissions_count': 1, 'choice': 'O'}),
+            Mock(username='audit', state={'submissions_count': 1}),
         )
 
     def test_generate_report_data_dont_limit_responses(self):
@@ -91,6 +92,7 @@ class TestPollBlock(unittest.TestCase):
                          ('edx', {'Question': self.poll_block.question,
                                   'Answer': 'Red',
                                   'Submissions count': 1}))
+        self.assertNotIn('audit', [username for username, _ in report_data])
 
     def test_generate_report_data_limit_responses(self):
         """
@@ -236,6 +238,7 @@ class TestSurveyBlock(unittest.TestCase):
             set(['Yes', 'No', 'Maybe']),
             set([data['Answer'] for _, data in report_data[:4]])
         )
+        self.assertNotIn('audit', [username for username, _ in report_data])
 
     def test_generate_report_data_limit_responses(self):
         """


### PR DESCRIPTION
This branch makes survey report generation more robust, protecting against the case where the stored user state for a survey response has no `choices` key.

## Steps to Reproduce

* In Studio, [enable the Survey XBlock](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/exercises_tools/survey.html#survey-tool).
* Add a Survey block to a course and publish the course.
* Login as a student.
* Respond to the survey.
* In Studio, edit the survey, remove the question and add a new one, then publish the course.
* As the student, revisit the survey.
* As an admin user, navigate to Courses > Your Course > Responses.
* Select your survey and click Download Responses.
  * In the LMS console, you will see an error:

```2019-02-28 18:04:17,162 WARNING 25065 [edx.celery.task] tasks_base.py:94 - Task (6a8fb678-c2ec-40c6-b70f-2bb410dc5949) failed
Traceback (most recent call last):
 File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/app/trace.py", line 240, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor_task/tasks.py", line 157, in calculate_problem_responses_csv
    return run_main_task(entry_id, task_fn, action_name)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor_task/tasks_helper/runner.py", line 113, in run_main_task
    task_progress = task_fcn(entry_id, course_id, task_input, action_name)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor_task/tasks_helper/grades.py", line 699, in generate
    filter_types=filter_types,
 File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor_task/tasks_helper/grades.py", line 634, in _build_student_data
    for username, state in block.generate_report_data(user_state_iterator, max_count):
  File "/edx/app/edxapp/venvs/edxapp/src/xblock-poll/poll/poll.py", line 1300, in generate_report_data
AttributeError: 'NoneType' object has no attribute 'items'
```

## Testing Steps
* Check out this branch to $(DEVSTACK_ROOT)/src (this is mounted as `/edx/src` in the Vagrant container).
* `vagrant ssh`
* `sudo su edxapp`
* `. ~/venvs/edxapp/bin/activate`
* `pip uninstall xblock-poll`
* `rm -rf ~/venvs/edxapp/src/xblock-poll`
* `pip install -e /edx/src/xblock-poll`
* Restart the LMS.
* Follow STR above.
  * The report should be generated as expected.