### PR TITLE
[MCKIN-10391] Fix issues updating completion

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -218,7 +218,7 @@ class PollBase(XBlock, ResourceMixin, PublishEventMixin):
     Base class for Poll-like XBlocks.
     """
     completion_mode = XBlockCompletionMode.COMPLETABLE
-    has_custom_completion = True  # manually submits progress event in send_vote_event
+    has_custom_completion = True  # manually submits completion event in send_vote_event
 
     has_author_view = True
 
@@ -232,7 +232,7 @@ class PollBase(XBlock, ResourceMixin, PublishEventMixin):
 
     def send_vote_event(self, choice_data):
         # Let the LMS know the user has answered the poll.
-        self.runtime.publish(self, 'progress', {})
+        self.runtime.publish(self, 'completion', {'completion': 1.0})
         # The SDK doesn't set url_name.
         event_dict = {'url_name': getattr(self, 'url_name', '')}
         event_dict.update(choice_data)

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-poll',
-    version='1.8.2',
+    version='1.8.3',
     description='An XBlock for polling users.',
     packages=[
         'poll',


### PR DESCRIPTION
The poll xblock has custom completion but was publishing a progress event instead of a completion event, which is no longer supported. 

This PR updates the block to use the new completion API instead. 

**Testing instructions**:

1. Set up a could with the poll xblock. 
2. Make sure completion is enabled. 
3. Respond to a poll. 
4. Check if the poll has been marked as complete using the UI or by checking for a correstponding BlockCompletion entry (``from completion.models import BlockCompletion``), checking ``BlockCompletion.objects.last()`` should work.
5. The completion will not be reported. 
6. Install the version of the XBlock from this PR, and restart the LMS.
7. Respond to another poll. 
8. Check the completion entries again, you should see a completion entry for the block.