### PR TITLE
Ensure survey radio button ID uniqueness across surveys

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -1261,7 +1261,7 @@ class SurveyBlock(PollBase, CSVExportMixin):
                                ["d", "Disagree"], ["sd", "Strongly Disagree"]]'
                      feedback="### Thank you&#10;&#10;for running the tests."/>
                  <survey tally='{"q1": {"sa": 5, "a": 5, "n": 3, "d": 2, "sd": 5}}'
-                     questions='[["q1", {"label": "Country most likely to win the World Cup.", "img": null, "img_alt": null}]]'
+                     questions='[["q1", {"label": "Most likely to win the World Cup.", "img": null, "img_alt": null}]]'
                      answers='[["sa", "South Africa"], ["a", "Angola"], ["n", "Netherlands"],
                                ["d", "Deutschland"], ["sd", "Someone different"]]'
                      feedback="### Thank you&#10;&#10;for running the tests."/>

--- a/poll/poll.py
+++ b/poll/poll.py
@@ -1251,7 +1251,22 @@ class SurveyBlock(PollBase, CSVExportMixin):
                  answers='[["sa", "Strongly Agree"], ["a", "Agree"], ["n", "Neutral"],
                            ["d", "Disagree"], ["sd", "Strongly Disagree"]]'
                  feedback="### Thank you&#10;&#10;for running the tests."/>
-             """)
+             """),
+            ("Survey Multiple",
+             """
+             <vertical_demo>
+                 <survey tally='{"q1": {"sa": 5, "a": 5, "n": 3, "d": 2, "sd": 5}}'
+                     questions='[["q1", {"label": "I feel like this test will pass.", "img": null, "img_alt": null}]]'
+                     answers='[["sa", "Strongly Agree"], ["a", "Agree"], ["n", "Neutral"],
+                               ["d", "Disagree"], ["sd", "Strongly Disagree"]]'
+                     feedback="### Thank you&#10;&#10;for running the tests."/>
+                 <survey tally='{"q1": {"sa": 5, "a": 5, "n": 3, "d": 2, "sd": 5}}'
+                     questions='[["q1", {"label": "Country most likely to win the World Cup.", "img": null, "img_alt": null}]]'
+                     answers='[["sa", "South Africa"], ["a", "Angola"], ["n", "Netherlands"],
+                               ["d", "Deutschland"], ["sd", "Someone different"]]'
+                     feedback="### Thank you&#10;&#10;for running the tests."/>
+             </vertical_demo>
+             """),
         ]
 
     def get_filename(self):

--- a/poll/public/html/survey.html
+++ b/poll/public/html/survey.html
@@ -29,10 +29,10 @@
                         {% with answer_count=forloop.counter %}
                             {% for answer, label in answers %}
                                 {% if forloop.counter == answer_count %}
-                                    <label for="{{key}}-{{answer_count}}">
+                                <label for="{{block_id}}-{{key}}-{{answer_count}}">
                                         <input type="radio"
                                                name="{{key}}"
-                                               id="{{key}}-{{forloop.counter}}"
+                                               id="{{block_id}}-{{key}}-{{forloop.counter}}"
                                                value="{{answer}}"{% if question.choice == answer %} checked{% endif %}
                                                {% if question.img_alt %}
                                                aria-label="{{question.img_alt}} {{label}}"

--- a/poll/public/html/survey.html
+++ b/poll/public/html/survey.html
@@ -29,7 +29,7 @@
                         {% with answer_count=forloop.counter %}
                             {% for answer, label in answers %}
                                 {% if forloop.counter == answer_count %}
-                                <label for="{{block_id}}-{{key}}-{{answer_count}}">
+                                    <label for="{{block_id}}-{{key}}-{{answer_count}}">
                                         <input type="radio"
                                                name="{{key}}"
                                                id="{{block_id}}-{{key}}-{{forloop.counter}}"

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-poll',
-    version='1.8.4',
+    version='1.8.5',
     description='An XBlock for polling users.',
     packages=[
         'poll',

--- a/tests/integration/test_functions.py
+++ b/tests/integration/test_functions.py
@@ -265,3 +265,14 @@ class TestSurveyFunctions(PollBaseTest):
 
         self.go_to_page('Poll Functions')
         self.assertFalse(self.get_submit().is_enabled())
+
+    def test_survey_radio_ids_unique(self):
+        """
+        Verify that multiple surveys on the same page with the same question
+        IDs still produce unique HTML radio button IDs.
+        """
+        self.go_to_page('Survey Multiple')
+        elements = self.browser.find_elements_by_css_selector('.survey-option input[type=radio]')
+        all_ids = sorted([element.get_attribute('id') for element in elements])
+        unique_ids = sorted(list(set(all_ids)))
+        self.assertSequenceEqual(all_ids, unique_ids)

--- a/tests/integration/xml/survey_multiple.xml
+++ b/tests/integration/xml/survey_multiple.xml
@@ -1,0 +1,12 @@
+<vertical_demo>
+    <survey tally='{"q1": {"sa": 5, "a": 5, "n": 3, "d": 2, "sd": 5}}'
+        questions='[["q1", {"label": "I feel like this test will pass.", "img": null, "img_alt": null}]]'
+        answers='[["sa", "Strongly Agree"], ["a", "Agree"], ["n", "Neutral"],
+                  ["d", "Disagree"], ["sd", "Strongly Disagree"]]'
+        feedback="### Thank you&#10;&#10;for running the tests."/>
+    <survey tally='{"q1": {"sa": 5, "a": 5, "n": 3, "d": 2, "sd": 5}}'
+        questions='[["q1", {"label": "Country most likely to win the World Cup.", "img": null, "img_alt": null}]]'
+        answers='[["sa", "South Africa"], ["a", "Angola"], ["n", "Netherlands"],
+                  ["d", "Deutschland"], ["sd", "Someone different"]]'
+        feedback="### Thank you&#10;&#10;for running the tests."/>
+</vertical_demo>


### PR DESCRIPTION
This branch ensures that the HTML ID of radio buttons in surveys is unique across surveys. This avoids the problem of duplicate HTML IDs when more than one survey is present in a single unit whose answer keys happen to overlap.

## Testing instructions

* Install this branch in your devstack
* In Studio, create a unit with two sample surveys - keep the default questions and answers - and publish it.
* In the LMS browse to the survey.
* Using the browser's developer tools (or show source), verify that each of the radio buttons in the two surveys has a unique HTML ID.