### PR TITLE
Fix Unregistered Celery Task Error

### DIFF
--- a/poll/tasks.py
+++ b/poll/tasks.py
@@ -7,7 +7,7 @@ from opaque_keys.edx.keys import CourseKey, UsageKey  # pylint: disable=import-e
 from xmodule.modulestore.django import modulestore  # pylint: disable=import-error
 
 
-@task()
+@task(name='poll.tasks.export_csv_data')
 def export_csv_data(block_id, course_id):
     """
     Exports student answers to all supported questions to a CSV file.

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-poll',
-    version='1.8.6',
+    version='1.8.7',
     description='An XBlock for polling users.',
     packages=[
         'poll',


### PR DESCRIPTION
The following celery task is not being executed:
* poll.tasks.export_csv_data

```
The message has been ignored and discarded.
Did you remember to import the module containing this task?
Or maybe you are using relative imports?
Please see http://bit.ly/gLye1c for more information.
The full contents of the message body was:
{u'utc': True, u'chord': None, u'args': [u'block-v1:HKPolyUx+HTM540x+2T2019a+type@survey+block@9da49dd09d954b5e9057cd520d032992', u'course-v1:HKPolyUx+HTM540x+2T2019a'], u'retries': 0, u'expires': None, u'task': u'poll.tasks.export_csv_data', u'callbacks': None, u'errbacks': None, u'timelimit': [None, None], u'taskset': None, u'kwargs': {}, u'eta': None, u'id': u'037df1ad-a8f8-40c2-a5ae-f3f8534aef46'} (387b)
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/worker/consumer.py", line 465, in on_task_received
    strategies[type_](message, body,
KeyError: u'poll.tasks.export_csv_data'
```


More details on why this happens [here](https://docs.celeryproject.org/en/latest/userguide/tasks.html#automatic-naming-and-relative-imports)
