### PR TITLE
Fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
+dist: xenial
+services:
+  - xvfb
 python:
     - "2.7"
-before_install:
-    - "export DISPLAY=:99"
-    - "sh -e /etc/init.d/xvfb start"
 install:
   - make requirements
 script:

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ extract_translations: ## extract strings to be translated, outputting .po files
 
 	# Extract Handlebars i18n strings
 	echo > locale/en/LC_MESSAGES/textjs.po  # Ensure it's empty
-	@# The sort to avoid bash arbitrary file order
+	# The sort to avoid bash arbitrary file order
 	ls poll/public/handlebars/*.handlebars | sort \
 	    | xargs node node_modules/.bin/xgettext-template --from-code utf8 \
 	        --language Handlebars \


### PR DESCRIPTION
It seems that since the previous PR (https://github.com/open-craft/xblock-poll/pull/60), the default distribution used by Travis CI has been changed from trusty to xenial, whcih causes the [old approach](https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-directly) of using xvfb to fail. This PR updated the OS in use to Xenial and uses the [newer approach](https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services).