### PR TITLE
Add missing charset to response

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -428,7 +428,7 @@ class PollBase(XBlock, ResourceMixin, PublishEventMixin):
         def wrapper(self, request_json, suffix=''):
             response = json.dumps(func(self, request_json, suffix))
             response = replace_static_urls(response, course_id=self.runtime.course_id)
-            return Response(response, content_type='application/json')
+            return Response(response, content_type='application/json', charset='utf8')
 
         if HAS_STATIC_REPLACE:
             # Only use URL translation if it is available


### PR DESCRIPTION
This code path doesn't get hit during the test suite because it depends on the existence of code from edx-platform, so it was missed during the Python 3 upgrade.  Just updated this response to match the others so it doesn't blow up with `TypeError: You cannot set the body to a text value without a charset` in production.