### PR TITLE
MCKIN-12693 Handle updated choice ids in polls

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -823,7 +823,8 @@ class PollBlock(PollBase, CSVExportMixin):
                 continue
             report = {
                 self.ugettext('Question'): self.question,
-                self.ugettext('Answer'): answers_dict.get(choice, {}).get('label') or "[Removed Poll Option {}]".format(choice),
+                self.ugettext('Answer'): answers_dict.get(choice, {}).get('label') or
+                                         "[Removed Poll Option {}]".format(choice),
                 self.ugettext('Submissions count'): user_state.state['submissions_count']
             }
             count += 1
@@ -1329,8 +1330,9 @@ class SurveyBlock(PollBase, CSVExportMixin):
                     # End the iterator here
                     return
 
-                question = questions_dict[question_id]['label']
-                answer = answers_dict[answer_id]
+                question = questions_dict.get(question_id, {}).get('label') \
+                           or "[Removed Survey Question {}]".format(question_id)
+                answer = answers_dict.get(answer_id) or "[Removed Survey Option {}]".format(question_id)
                 report = {
                     self.ugettext('Question'): question,
                     self.ugettext('Answer'): answer,

--- a/poll/poll.py
+++ b/poll/poll.py
@@ -823,8 +823,8 @@ class PollBlock(PollBase, CSVExportMixin):
                 continue
             report = {
                 self.ugettext('Question'): self.question,
-                self.ugettext('Answer'): answers_dict.get(choice, {}).get('label') or
-                                         "[Removed Poll Option {}]".format(choice),
+                self.ugettext('Answer'): answers_dict.get(choice, {}).get('label',
+                                                                          "[Removed Poll Option {}]".format(choice)),
                 self.ugettext('Submissions count'): user_state.state['submissions_count']
             }
             count += 1
@@ -1330,9 +1330,9 @@ class SurveyBlock(PollBase, CSVExportMixin):
                     # End the iterator here
                     return
 
-                question = questions_dict.get(question_id, {}).get('label') \
-                           or "[Removed Survey Question {}]".format(question_id)
-                answer = answers_dict.get(answer_id) or "[Removed Survey Option {}]".format(question_id)
+                question = questions_dict.get(question_id, {}).get('label',
+                                                                   "[Removed Survey Question {}]".format(question_id))
+                answer = answers_dict.get(answer_id) or "[Removed Survey Option {}]".format(answer_id)
                 report = {
                     self.ugettext('Question'): question,
                     self.ugettext('Answer'): answer,

--- a/poll/poll.py
+++ b/poll/poll.py
@@ -823,7 +823,7 @@ class PollBlock(PollBase, CSVExportMixin):
                 continue
             report = {
                 self.ugettext('Question'): self.question,
-                self.ugettext('Answer'): answers_dict.get(choice, {}).get('label', ''),
+                self.ugettext('Answer'): answers_dict.get(choice, {}).get('label') or "[Removed Poll Option {}]".format(choice),
                 self.ugettext('Submissions count'): user_state.state['submissions_count']
             }
             count += 1

--- a/poll/poll.py
+++ b/poll/poll.py
@@ -823,7 +823,7 @@ class PollBlock(PollBase, CSVExportMixin):
                 continue
             report = {
                 self.ugettext('Question'): self.question,
-                self.ugettext('Answer'): answers_dict[choice]['label'],
+                self.ugettext('Answer'): answers_dict.get(choice, {}).get('label', ''),
                 self.ugettext('Submissions count'): user_state.state['submissions_count']
             }
             count += 1

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-poll',
-    version='1.9.0',
+    version='1.9.1',
     description='An XBlock for polling users.',
     packages=[
         'poll',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-poll',
-    version='1.9.1',
+    version='1.9.2',
     description='An XBlock for polling users.',
     packages=[
         'poll',


### PR DESCRIPTION
Jira tikcet: https://edx-wiki.atlassian.net/browse/MCKIN-12693
If a choice is updated/added in polls after a user has submitted a response for the old choice, this code crashes since the id for the new choice has changed.

The code crash occurs while generating polls/survey responses.