### PR TITLE
WIP - Fix most frequent deprecation warnings

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -36,7 +36,7 @@ from webob import Response
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
 from xblock.fields import Boolean, Dict, Integer, List, Scope, String
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 from xblockutils.publish_event import PublishEventMixin
 from xblockutils.resources import ResourceLoader
 from xblockutils.settings import ThemableXBlockMixin, XBlockWithSettingsMixin
@@ -554,7 +554,7 @@ class PollBlock(PollBase, CSVExportMixin):
         if not context:
             context = {}
         js_template = self.resource_string(
-            '/public/handlebars/poll_results.handlebars')
+            'public/handlebars/poll_results.handlebars')
 
         choice = self.get_choice()
 
@@ -618,7 +618,7 @@ class PollBlock(PollBase, CSVExportMixin):
         if not context:
             context = {}
 
-        js_template = self.resource_string('/public/handlebars/poll_studio.handlebars')
+        js_template = self.resource_string('public/handlebars/poll_studio.handlebars')
         context.update({
             'question': self.question,
             'display_name': self.display_name,
@@ -629,7 +629,7 @@ class PollBlock(PollBase, CSVExportMixin):
         })
         return self.create_fragment(
             context, "public/html/poll_edit.html",
-            "/public/css/poll_edit.css", "public/js/poll_edit.js", "PollEdit")
+            "public/css/poll_edit.css", "public/js/poll_edit.js", "PollEdit")
 
     @XBlock.json_handler
     def load_answers(self, data, suffix=''):
@@ -887,7 +887,7 @@ class SurveyBlock(PollBase, CSVExportMixin):
             context = {}
 
         js_template = self.resource_string(
-            '/public/handlebars/survey_results.handlebars')
+            'public/handlebars/survey_results.handlebars')
 
         choices = self.get_choices()
 
@@ -960,7 +960,7 @@ class SurveyBlock(PollBase, CSVExportMixin):
         if not context:
             context = {}
 
-        js_template = self.resource_string('/public/handlebars/poll_studio.handlebars')
+        js_template = self.resource_string('public/handlebars/poll_studio.handlebars')
         context.update({
             'feedback': self.feedback,
             'display_name': self.block_name,
@@ -971,7 +971,7 @@ class SurveyBlock(PollBase, CSVExportMixin):
         })
         return self.create_fragment(
             context, "public/html/poll_edit.html",
-            "/public/css/poll_edit.css", "public/js/poll_edit.js", "SurveyEdit")
+            "public/css/poll_edit.css", "public/js/poll_edit.js", "SurveyEdit")
 
     def tally_detail(self):
         """

--- a/poll/poll.py
+++ b/poll/poll.py
@@ -958,7 +958,7 @@ class SurveyBlock(PollBase, CSVExportMixin):
         if not context:
             context = {}
 
-        js_template = self.resource_string('/public/handlebars/poll_studio.handlebars')
+        js_template = self.resource_string('public/handlebars/poll_studio.handlebars')
         context.update({
             'feedback': self.feedback,
             'display_name': self.block_name,
@@ -969,7 +969,7 @@ class SurveyBlock(PollBase, CSVExportMixin):
         })
         return self.create_fragment(
             context, "public/html/poll_edit.html",
-            "/public/css/poll_edit.css", "public/js/poll_edit.js", "SurveyEdit")
+            "public/css/poll_edit.css", "public/js/poll_edit.js", "SurveyEdit")
 
     def tally_detail(self):
         """

--- a/poll/poll.py
+++ b/poll/poll.py
@@ -553,8 +553,7 @@ class PollBlock(PollBase, CSVExportMixin):
         """
         if not context:
             context = {}
-        js_template = self.resource_string(
-            'public/handlebars/poll_results.handlebars')
+        js_template = self.resource_string('/public/handlebars/poll_results.handlebars')
 
         choice = self.get_choice()
 
@@ -618,7 +617,7 @@ class PollBlock(PollBase, CSVExportMixin):
         if not context:
             context = {}
 
-        js_template = self.resource_string('public/handlebars/poll_studio.handlebars')
+        js_template = self.resource_string('/public/handlebars/poll_studio.handlebars')
         context.update({
             'question': self.question,
             'display_name': self.display_name,
@@ -629,7 +628,7 @@ class PollBlock(PollBase, CSVExportMixin):
         })
         return self.create_fragment(
             context, "public/html/poll_edit.html",
-            "public/css/poll_edit.css", "public/js/poll_edit.js", "PollEdit")
+            "/public/css/poll_edit.css", "public/js/poll_edit.js", "PollEdit")
 
     @XBlock.json_handler
     def load_answers(self, data, suffix=''):
@@ -886,8 +885,7 @@ class SurveyBlock(PollBase, CSVExportMixin):
         if not context:
             context = {}
 
-        js_template = self.resource_string(
-            'public/handlebars/survey_results.handlebars')
+        js_template = self.resource_string('/public/handlebars/survey_results.handlebars')
 
         choices = self.get_choices()
 
@@ -960,7 +958,7 @@ class SurveyBlock(PollBase, CSVExportMixin):
         if not context:
             context = {}
 
-        js_template = self.resource_string('public/handlebars/poll_studio.handlebars')
+        js_template = self.resource_string('/public/handlebars/poll_studio.handlebars')
         context.update({
             'feedback': self.feedback,
             'display_name': self.block_name,
@@ -971,7 +969,7 @@ class SurveyBlock(PollBase, CSVExportMixin):
         })
         return self.create_fragment(
             context, "public/html/poll_edit.html",
-            "public/css/poll_edit.css", "public/js/poll_edit.js", "SurveyEdit")
+            "/public/css/poll_edit.css", "public/js/poll_edit.js", "SurveyEdit")
 
     def tally_detail(self):
         """

--- a/poll/poll.py
+++ b/poll/poll.py
@@ -621,7 +621,7 @@ class PollBlock(PollBase, CSVExportMixin):
         if not context:
             context = {}
 
-        js_template = self.resource_string('/public/handlebars/poll_studio.handlebars')
+        js_template = self.resource_string('public/handlebars/poll_studio.handlebars')
         context.update({
             'question': self.question,
             'display_name': self.display_name,
@@ -631,8 +631,12 @@ class PollBlock(PollBase, CSVExportMixin):
             'max_submissions': self.max_submissions,
         })
         return self.create_fragment(
-            context, "public/html/poll_edit.html",
-            "/public/css/poll_edit.css", "public/js/poll_edit.js", "PollEdit")
+            context,
+            template="public/html/poll_edit.html",
+            css="public/css/poll_edit.css",
+            js="public/js/poll_edit.js",
+            js_init="PollEdit"
+        )
 
     @XBlock.json_handler
     def load_answers(self, data, suffix=''):
@@ -889,7 +893,7 @@ class SurveyBlock(PollBase, CSVExportMixin):
         if not context:
             context = {}
 
-        js_template = self.resource_string('/public/handlebars/survey_results.handlebars')
+        js_template = self.resource_string('public/handlebars/survey_results.handlebars')
 
         choices = self.get_choices()
 
@@ -913,8 +917,12 @@ class SurveyBlock(PollBase, CSVExportMixin):
             'usage_id': six.text_type(self.scope_ids.usage_id),
         })
         return self.create_fragment(
-            context, "public/html/survey.html", "public/css/poll.css",
-            "public/js/poll.js", "SurveyBlock")
+            context,
+            template="public/html/survey.html",
+            css="public/css/poll.css",
+            js="public/js/poll.js",
+            js_init="SurveyBlock"
+        )
 
     def student_view_data(self, context=None):
         """

--- a/poll/poll.py
+++ b/poll/poll.py
@@ -553,7 +553,7 @@ class PollBlock(PollBase, CSVExportMixin):
         """
         if not context:
             context = {}
-        js_template = self.resource_string('/public/handlebars/poll_results.handlebars')
+        js_template = self.resource_string('public/handlebars/poll_results.handlebars')
 
         choice = self.get_choice()
 
@@ -580,8 +580,12 @@ class PollBlock(PollBase, CSVExportMixin):
             context.update({'tally': detail, 'total': total, 'plural': total > 1})
 
         return self.create_fragment(
-            context, "public/html/poll.html", "public/css/poll.css",
-            "public/js/poll.js", "PollBlock")
+            context,
+            template="public/html/poll.html",
+            css="public/css/poll.css",
+            js="public/js/poll.js",
+            js_init="PollBlock"
+        )
 
     def student_view_data(self, context=None):
         """
@@ -968,8 +972,12 @@ class SurveyBlock(PollBase, CSVExportMixin):
             'multiquestion': True,
         })
         return self.create_fragment(
-            context, "public/html/poll_edit.html",
-            "public/css/poll_edit.css", "public/js/poll_edit.js", "SurveyEdit")
+            context,
+            template="public/html/poll_edit.html",
+            css="public/css/poll_edit.css",
+            js="public/js/poll_edit.js",
+            js_init="SurveyEdit"
+        )
 
     def tally_detail(self):
         """

--- a/poll/poll.py
+++ b/poll/poll.py
@@ -37,7 +37,6 @@ from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
 from xblock.fields import Boolean, Dict, Integer, List, Scope, String
 from web_fragments.fragment import Fragment
-
 from xblockutils.publish_event import PublishEventMixin
 from xblockutils.resources import ResourceLoader
 from xblockutils.settings import ThemableXBlockMixin, XBlockWithSettingsMixin

--- a/poll/poll.py
+++ b/poll/poll.py
@@ -37,6 +37,7 @@ from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
 from xblock.fields import Boolean, Dict, Integer, List, Scope, String
 from web_fragments.fragment import Fragment
+
 from xblockutils.publish_event import PublishEventMixin
 from xblockutils.resources import ResourceLoader
 from xblockutils.settings import ThemableXBlockMixin, XBlockWithSettingsMixin


### PR DESCRIPTION
Fixed the most frequently occurring deprecation warnings.

```
Use of .. or absolute path in a resource path is not allowed and will raise exceptions in a future release
``` 
- most of these were due to a single mis-configured resource path with a leading slash.

```
xblock.fragment is deprecated. Please use web_fragments.fragment instead
```

FYI -- @jmbowman, @xitij2000 