### PR TITLE
Fixed StudentModule conflicting path 

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -186,7 +186,7 @@ class CSVExportMixin(object):
         return dict(report_store.links_for(course_key)).get(self.last_export_result['report_filename'])
 
     def student_module_queryset(self):
-        from courseware.models import StudentModule  # pylint: disable=import-error
+        from lms.djangoapps.courseware.models import StudentModule  # pylint: disable=import-error
         return StudentModule.objects.select_related('student').filter(
             course_id=self.runtime.course_id,
             module_state_key=self.scope_ids.usage_id,
@@ -789,7 +789,7 @@ class PollBlock(PollBase, CSVExportMixin):
                     self.question,
                     answers_dict[choice]['label'],
                 ]
-        return [header_row] + data.values()
+        return [header_row] + list(data.values())
 
     def generate_report_data(self, user_state_iterator, limit_responses=None):
         """

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-poll',
-    version='1.9.4',
+    version='1.9.5',
     description='An XBlock for polling users.',
     packages=[
         'poll',


### PR DESCRIPTION
[PROD-1295](https://openedx.atlassian.net/browse/PROD-1295)

Issue:
People were unable to download poll reports due to conflict in StudentModule 

Fix: 
Updated StudentModule path and there was another issue with the concatenation of the list which seems likely was caused due to python update.