### PR TITLE
Fix deprecated edx-platform import of static_replace

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -53,7 +53,7 @@ except ImportError:
 
 try:
     # pylint: disable=import-error
-    from static_replace import replace_static_urls
+    from common.djangoapps.static_replace import replace_static_urls
     HAS_STATIC_REPLACE = True
 except ImportError:
     HAS_STATIC_REPLACE = False

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-poll',
-    version='1.10.1',
+    version='1.10.2',
     description='An XBlock for polling users.',
     packages=[
         'poll',


### PR DESCRIPTION
```
The correct import is
`common.djangoapps.static_replace`.

Support for the deprecated import path will be removed soon.

Bump version to 1.10.2
```

See [this forum post for context](https://discuss.openedx.org/t/koa-will-change-how-edx-platform-code-is-imported/3610).

This is related to the [the impending removal of support for deprecated edx-platform import paths](https://github.com/edx/edx-platform/pull/25932).