### PR TITLE
Fix error message display when CSV export fails [MNG-2273]

### DIFF
--- a/poll/public/js/poll.js
+++ b/poll/public/js/poll.js
@@ -182,7 +182,7 @@ function PollUtil (runtime, element, pollType) {
         else {
             if (statusChanged) {
                 if (newStatus.last_export_result.error) {
-                    self.errorMessage.text(error);
+                    self.errorMessage.text("Error: " + newStatus.last_export_result.error);
                     self.errorMessage.show();
                 } else {
                     self.downloadResultsButton.attr('disabled', false);


### PR DESCRIPTION
If the "Export to CSV" button fails to launch a task, it currently doesn't display the error message properly. Instead, an error message can only be seen in the browser console, which just says `error is undefined`.

This fixes the code so that the actual error message will be displayed:
<img width="865" alt="Screen Shot 2021-06-23 at 5 44 45 PM" src="https://user-images.githubusercontent.com/945577/123186493-1da73600-d44d-11eb-85df-4f047900a839.png">

See https://openedx.atlassian.net/browse/TNL-8370 and https://github.com/edx/edx-platform/pull/28019 for more information about this issue.