### PR TITLE
feat: upgrade poll XBlock to use celery 5.0+ features

### DIFF
--- a/poll/tasks.py
+++ b/poll/tasks.py
@@ -1,14 +1,14 @@
 from __future__ import absolute_import
 import time
 
-from celery.decorators import task  # pylint: disable=import-error
+from celery import current_app  # pylint: disable=import-error
 
 from lms.djangoapps.instructor_task.models import ReportStore  # pylint: disable=import-error
 from opaque_keys.edx.keys import CourseKey, UsageKey  # pylint: disable=import-error
 from xmodule.modulestore.django import modulestore  # pylint: disable=import-error
 
 
-@task(name='poll.tasks.export_csv_data')
+@current_app.task(name='poll.tasks.export_csv_data')
 def export_csv_data(block_id, course_id):
     """
     Exports student answers to all supported questions to a CSV file.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-poll',
-    version='1.11.0',
+    version='1.12.0',
     description='An XBlock for polling users.',
     packages=[
         'poll',


### PR DESCRIPTION
## Description

Celery did remove the `celery.decorators` module, or at least `tasks` is not part of that anymore. Therefore, mimicking the previous behaviour, we have to import the current Celery app and use that task.

## Supporting information

OpenCraft currently upgrading Celery on the edX platform:

* https://github.com/edx/configuration/pull/6586
* https://github.com/edx/edx-platform/pull/29046

### Screenshots

## Sandbox

Under provisioning

## Testing instructions

1. Log in to the instance
2. Create a poll
3. Check the poll is created

## Deadline

None

## Other information

N/A