### PR TITLE
chore: fix depr warning by updating import: xblockutils -> xblock.utils

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -32,14 +32,19 @@ import pkg_resources
 import six
 from django import utils
 from markdown import markdown
-from webob import Response
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
 from xblock.fields import Boolean, Dict, Integer, List, Scope, String
+try:
+    from xblock.utils.publish_event import PublishEventMixin
+    from xblock.utils.resources import ResourceLoader
+    from xblock.utils.settings import ThemableXBlockMixin, XBlockWithSettingsMixin
+except ModuleNotFoundError:  # For backward compatibility with releases older than Quince.
+    from xblockutils.publish_event import PublishEventMixin
+    from xblockutils.resources import ResourceLoader
+    from xblockutils.settings import ThemableXBlockMixin, XBlockWithSettingsMixin
+from webob import Response
 from web_fragments.fragment import Fragment
-from xblockutils.publish_event import PublishEventMixin
-from xblockutils.resources import ResourceLoader
-from xblockutils.settings import ThemableXBlockMixin, XBlockWithSettingsMixin
 
 from .utils import DummyTranslationService, _, remove_markdown_and_html_tags
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ README = open(os.path.join(os.path.dirname(__file__), 'README.md'), encoding="ut
 
 setup(
     name='xblock-poll',
-    version='1.13.0',
+    version='1.13.1',
     description='An XBlock for polling users.',
     long_description=README,
     long_description_content_type='text/markdown',

--- a/tests/integration/base_test.py
+++ b/tests/integration/base_test.py
@@ -22,9 +22,9 @@
 #
 
 from __future__ import absolute_import
-from xblockutils.base_test import SeleniumBaseTest
 from mock import patch
 
+from xblock.utils.base_test import SeleniumBaseTest
 
 # Default names for inputs for polls/surveys
 DEFAULT_SURVEY_NAMES = ('enjoy', 'recommend', 'learn')


### PR DESCRIPTION
Context: https://github.com/openedx/XBlock/issues/675

Fixes some edx-platform warnings:
```
2024-01-09 14:45:42,875 WARNING 289 [py.warnings] [user None] [ip None] warnings.py:109 - /openedx/venv/lib/python3.8/site-packages/poll/poll.py:40: DeprecatedPackageWarning: Please use import xblock.utils.publish_event instead of xblockutils.publish_event because the 'xblock-utils' package has been deprecated and migrated to within 'xblock' package. 
  from xblockutils.publish_event import PublishEventMixin

2024-01-09 14:45:42,875 WARNING 289 [py.warnings] [user None] [ip None] warnings.py:109 - /openedx/venv/lib/python3.8/site-packages/poll/poll.py:41: DeprecatedPackageWarning: Please use import xblock.utils.resources instead of xblockutils.resources because the 'xblock-utils' package has been deprecated and migrated to within 'xblock' package. 
  from xblockutils.resources import ResourceLoader

2024-01-09 14:45:42,875 WARNING 289 [py.warnings] [user None] [ip None] warnings.py:109 - /openedx/venv/lib/python3.8/site-packages/poll/poll.py:42: DeprecatedPackageWarning: Please use import xblock.utils.settings instead of xblockutils.settings because the 'xblock-utils' package has been deprecated and migrated to within 'xblock' package. 
  from xblockutils.settings import ThemableXBlockMixin, XBlockWithSettingsMixin
```

Uses a try-catch for backwards compatibility with pre-Quince versions
of xblock and xblockutils

Bumps version from 1.13.0 to 1.13.1

Resolves https://github.com/open-craft/xblock-poll/issues/114.