### PR TITLE
refactor: Move preventDefault in move up and move down events [FC-0076]

### DIFF
--- a/poll/__init__.py
+++ b/poll/__init__.py
@@ -23,4 +23,4 @@
 
 from .poll import PollBlock, SurveyBlock
 
-__version__ = "1.14.0"
+__version__ = "1.14.1"

--- a/poll/public/js/poll_edit.js
+++ b/poll/public/js/poll_edit.js
@@ -108,6 +108,7 @@ function PollEditUtil(runtime, element, pollType) {
     this.empowerArrows = function(scope, topMarker, bottomMarker) {
         // Activates the arrows on rendered line items.
         $('.poll-move-up', scope).click(function (ev) {
+            ev.preventDefault();
             var tag = $(this).parents('li');
             if (tag.index() <= ($(topMarker).index() + 1)){
                 return;
@@ -115,9 +116,9 @@ function PollEditUtil(runtime, element, pollType) {
             tag.prev().before(tag);
             tag.fadeOut(0).fadeIn('slow', 'swing');
             self.scrollTo(tag);
-            ev.preventDefault();
         });
-        $('.poll-move-down', scope).click(function () {
+        $('.poll-move-down', scope).click(function (ev) {
+            ev.preventDefault();
             var tag = $(this).parents('li');
             if ((tag.index() >= ($(bottomMarker).index() - 1))) {
                 return;
@@ -125,7 +126,6 @@ function PollEditUtil(runtime, element, pollType) {
             tag.next().after(tag);
             tag.fadeOut(0).fadeIn('slow', 'swing');
             self.scrollTo(tag);
-            ev.preventDefault();
         });
     };
 


### PR DESCRIPTION
## Description

- Move the `preventDefault` function before the conditional in `poll-move-up` and `poll-move-down` click events.
- This change is to avoid opening a new tab page when clicking the Move up/Move down buttons when the Poll block is in an Iframe

## Suporting information

- Related bug: [Testing report of Advanced block editors](https://docs.google.com/document/d/1-noO87_eIzc1A4FHNiO9kdlU30t60OaYHqVBxg9tfHo/edit?tab=t.0#heading=h.9gff493zcqs1)
- Internal ticket: [FAL-4041](https://tasks.opencraft.com/browse/FAL-4041)

## Testing instructions

- Checkout this branch locally
- Add it to the tutor mount list using `tutor mounts add ./xblock-poll`
- Rebuild images using `tutor images build openedx-dev`
- Go to a Course
- Go to `Settings > Advanced Settings` on the header menu
- Make sure you have `poll` and `survey` on the "Advanced Module List"
- Ensure you have `poll` and `survey` on the `LIBRARY_SUPPORTED_BLOCKS` on the `.env.development` file of the frontend-app-authoring.
- Run `tutor config save`
- Edit a Unit for a Course
- Add a poll and survey blocks to a Unit.
- Copy both blocks and paste them into a library.
- Edit the poll block, check that the "Move up" and "Move down" buttons work well, and don't open a new page.
- Edit the survey block, check that the "Move up" and "Move down" buttons work well, and don't open a new page.