### PR TITLE
fix: delete answers now remove the entire container

### DIFF
--- a/poll/__init__.py
+++ b/poll/__init__.py
@@ -23,4 +23,4 @@
 
 from .poll import PollBlock, SurveyBlock
 
-__version__ = "1.15.0"
+__version__ = "1.15.1"

--- a/poll/public/js/poll_edit.js
+++ b/poll/public/js/poll_edit.js
@@ -101,7 +101,7 @@ function PollEditUtil(runtime, element, pollType) {
     this.empowerDeletes = function (scope) {
         // Activates the delete buttons on rendered line items.
         $('.poll-delete-answer', scope).click(function () {
-            $(this).parent().remove();
+            $(this).parent().parent().remove();
         });
     };
 


### PR DESCRIPTION
## Description
Select the correct container when removing an answer.
Fixes: https://github.com/openedx/wg-build-test-release/issues/455

## Before
When deleting an answer, the hint text was not being removed
![image](https://github.com/user-attachments/assets/23b7e7fd-bf3b-4ac6-8729-af0facb7ae71)
![image](https://github.com/user-attachments/assets/6848497a-b7c6-4732-a835-ff39d005de64)


##After
Deleting an answer correctly deletes the whole container.

https://github.com/user-attachments/assets/2697baa1-7f1e-422c-8565-8680eb5cf919

