### PR TITLE
fix: show errors when inputs are incorrect

### DIFF
--- a/poll/__init__.py
+++ b/poll/__init__.py
@@ -23,4 +23,4 @@
 
 from .poll import PollBlock, SurveyBlock
 
-__version__ = "1.15.0"
+__version__ = "1.15.1"

--- a/poll/public/css/poll_edit.css
+++ b/poll/public/css/poll_edit.css
@@ -46,6 +46,32 @@
     float: right;
 }
 
+#poll-error-container {
+    background-color: #f8d7da;
+    border: 1px solid #f5c6cb;
+    color: #721c24;
+    padding: 10px;
+    margin: 10px 0;
+    border-radius: 4px;
+    font-weight: 500;
+    display: none; 
+    cursor: pointer; 
+}
+
+#poll-error-container:hover {
+    background-color: #f5c2c7;
+    transition: background-color 0.3s ease;
+}
+
+#poll-error-container:before {
+    content: "⚠️ ";
+}
+
+#poll-error-message {
+    display: inline-block;
+    margin-top: 5px;
+}
+
 .poll-setting-label {
     text-transform: capitalize;
 }

--- a/poll/public/html/poll_edit.html
+++ b/poll/public/html/poll_edit.html
@@ -107,6 +107,9 @@
             <li class="action-item">
                 <a href="#" class="button cancel-button">{% trans 'Cancel' %}</a>
             </li>
+            <li class="error-message" id="poll-error-container" title="Click to dismiss">
+                <span class="action-item" id="poll-error-message"></span>
+            </li>
         </ul>
     </div>
     </form>

--- a/poll/public/js/poll_edit.js
+++ b/poll/public/js/poll_edit.js
@@ -14,6 +14,14 @@ function PollEditUtil(runtime, element, pollType) {
         // Set up the editing form for a Poll or Survey.
         var temp = $('.poll-form-component', element).html();
 
+        // Hide error container initially
+        $('#poll-error-container', element).hide();
+        
+        // Allow clicking on the error message to dismiss it
+        $('#poll-error-container', element).click(function() {
+            $(this).hide();
+        });
+
         PollCommonUtil.init(Handlebars);
 
         self.answerTemplate = Handlebars.compile(temp);
@@ -234,6 +242,8 @@ function PollEditUtil(runtime, element, pollType) {
         data['private_results'] = eval($('#poll-private-results', element).val());
 
         if (notify) {
+            // Hide any previous error messages
+            $('#poll-error-container', element).hide();
             runtime.notify('save', {state: 'start', message: gettext("Saving")});
         }
         $.ajax({
@@ -246,9 +256,14 @@ function PollEditUtil(runtime, element, pollType) {
                 if (result['success'] && notify) {
                     runtime.notify('save', {state: 'end'})
                 } else if (notify) {
+                    // Format and display the error message
+                    var errorMessage = self.format_errors(result['errors']);
+                    $('#poll-error-message', element).html(errorMessage);
+                    $('#poll-error-container', element).show();
+                    
                     runtime.notify('error', {
                         'title': 'Error saving poll',
-                        'message': self.format_errors(result['errors'])
+                        'message': errorMessage
                     });
                 }
             }


### PR DESCRIPTION
Received feedback on this issue: https://github.com/openedx/wg-build-test-release/issues/454

When there is an error on the fields of a poll, there is no feedback to the user, so they don't know they hace to fix something. 
The validation and error handling is being done on the backend, so in order to make validations on the frontend and point exactly to the input with the issue we would have to move/replicate all the validation logic on the frontend, which I'm not sure we want to do.
My proposal to avoid that re-work and still let the user know that there are issue they have to fix, is to add an `Error section` that will be hidden at first, and if there are any issues that came from the backend, we can list them there.

Please look at the following video.

https://github.com/user-attachments/assets/e3f08d1e-531f-41d1-b771-f6d54aadd820

Let me know if this proposal works for you, otherwise let me know what is a better approach and I can work on it : D
