### PR TITLE
feat: sanitizing markdown and other xblock fields

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -27,7 +27,6 @@ import time
 from collections import OrderedDict
 
 from django import utils
-from markdown import markdown
 from web_fragments.fragment import Fragment
 from webob import Response
 from xblock.completable import XBlockCompletionMode
@@ -37,7 +36,7 @@ from xblock.utils.publish_event import PublishEventMixin
 from xblock.utils.resources import ResourceLoader
 from xblock.utils.settings import ThemableXBlockMixin, XBlockWithSettingsMixin
 
-from .utils import DummyTranslationService, _, remove_markdown_and_html_tags
+from .utils import DummyTranslationService, _, remove_markdown_and_html_tags, render_markdown
 
 try:
     # pylint: disable=import-error, bad-option-value, ungrouped-imports
@@ -249,7 +248,7 @@ class PollBase(XBlock, ResourceMixin, PublishEventMixin):
         """
         Convert all items' labels into markdown.
         """
-        return [(key, {'label': markdown(value['label']), 'img': value['img'], 'img_alt': value.get('img_alt')})
+        return [(key, {'label': render_markdown(value['label']), 'img': value['img'], 'img_alt': value.get('img_alt')})
                 for key, value in items]
 
     def _get_block_id(self):
@@ -553,10 +552,10 @@ class PollBlock(PollBase, CSVExportMixin):
         context.update({
             'choice': choice,
             'answers': self.markdown_items(self.answers),
-            'question': markdown(self.question),
+            'question': render_markdown(self.question),
             'private_results': self.private_results,
             # Mustache is treating an empty string as true.
-            'feedback': markdown(self.feedback) or False,
+            'feedback': render_markdown(self.feedback) or False,
             'js_template': js_template,
             'any_img': self.any_image(self.answers),
             'display_name': self.display_name,
@@ -651,10 +650,10 @@ class PollBlock(PollBase, CSVExportMixin):
             self.publish_event_from_dict(self.event_namespace + '.view_results', {})
             detail, total = self.tally_detail()
         return {
-            'question': markdown(self.question),
+            'question': render_markdown(self.question),
             'tally': detail,
             'total': total,
-            'feedback': markdown(self.feedback),
+            'feedback': render_markdown(self.feedback),
             'plural': total > 1,
             'display_name': self.display_name,
             'any_img': self.any_image(self.answers),
@@ -934,7 +933,7 @@ class SurveyBlock(PollBase, CSVExportMixin):
             'private_results': self.private_results,
             'any_img': self.any_image(self.questions),
             # Mustache is treating an empty string as true.
-            'feedback': markdown(self.feedback) or False,
+            'feedback': render_markdown(self.feedback) or False,
             'block_name': self.block_name,
             'can_vote': self.can_vote(),
             'submissions_count': self.submissions_count,
@@ -1148,7 +1147,7 @@ class SurveyBlock(PollBase, CSVExportMixin):
             ],
             'tally': detail,
             'total': total,
-            'feedback': markdown(self.feedback),
+            'feedback': render_markdown(self.feedback),
             'plural': total > 1,
             'block_name': self.block_name,
             # a11y: Transfer block ID to enable creating unique ids for questions and answers in the template

--- a/poll/public/handlebars/survey_results.handlebars
+++ b/poll/public/handlebars/survey_results.handlebars
@@ -7,7 +7,7 @@
                 <tr>
                     <td></td>
                     {{#each answers}}
-                        <th id="answer-{{key}}-{{../block_id}}" class="survey-answer">{{{label}}}</th>
+                        <th id="answer-{{key}}-{{../block_id}}" class="survey-answer">{{label}}</th>
                     {{/each}}
                 </tr>
             </thead>

--- a/poll/public/html/survey.html
+++ b/poll/public/html/survey.html
@@ -37,7 +37,7 @@
                                                {% if question.img_alt %}
                                                aria-label="{{question.img_alt}} {{label}}"
                                                {% else %}
-                                               aria-label="{{label|safe}}"
+                                               aria-label="{{label}}"
                                                {% endif %}
                                         />
                                         <span class="visible-mobile-only">{{label}}</span>

--- a/poll/utils.py
+++ b/poll/utils.py
@@ -3,10 +3,44 @@
 from bleach.sanitizer import Cleaner
 from markdown import markdown
 
+# Tags and attributes allowed in author-authored content (question, feedback and
+# answer/question labels) after it has been rendered from Markdown to HTML. Any
+# other markup is stripped so the rendered HTML is safe to emit directly into the
+# page (via ``|safe`` in Django templates and ``{{{ }}}`` in Handlebars).
+MARKDOWN_ALLOWED_TAGS = [
+    'a', 'abbr', 'acronym', 'b', 'blockquote', 'br', 'code', 'em',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i', 'img', 'li', 'ol',
+    'p', 'pre', 'strong', 'sub', 'sup', 'u', 'ul',
+]
+MARKDOWN_ALLOWED_ATTRIBUTES = {
+    'a': ['href', 'title'],
+    'img': ['src', 'alt', 'title'],
+}
+# Only allow safe URL protocols, so e.g. ``javascript:`` links are dropped.
+MARKDOWN_ALLOWED_PROTOCOLS = ['http', 'https', 'mailto']
+
 
 # Make '_' a no-op so we can scrape strings
 def _(text):
     return text
+
+
+def render_markdown(data):
+    """
+    Render Markdown to HTML, then sanitize it against an allow-list of tags,
+    attributes and protocols.
+
+    Markdown allows raw HTML to pass through untouched, so its output must be
+    sanitized before being rendered unescaped to prevent stored XSS from
+    author-supplied content.
+    """
+    cleaner = Cleaner(
+        tags=MARKDOWN_ALLOWED_TAGS,
+        attributes=MARKDOWN_ALLOWED_ATTRIBUTES,
+        protocols=MARKDOWN_ALLOWED_PROTOCOLS,
+        strip=True,
+    )
+    return cleaner.clean(markdown(data))
 
 
 def ngettext_fallback(text_singular, text_plural, number):


### PR DESCRIPTION
Motivation

Polls and surveys let course authors write rich text — questions, feedback, and answer/question labels — using Markdown. That's a lovely authoring experience, and I want to keep it. But Markdown is HTML's friendly front-end: whatever HTML you hand it flows straight through to the rendered page. As this XBlock has grown, that rendered HTML ends up trusted in a lot of places, and I'd rather we be deliberate about that trust than assume it.


This PR introduces a single, well-defined sanitization boundary so that everything an author writes is rendered through an explicit allow-list before it reaches the page. It's the kind of belt-and-suspenders hardening I'd want in place regardless of whether anything is wrong today — defense in depth, applied once, in the right spot.


Notes

- No new dependencies; no changes for normal author content (Markdown formatting, links, and images all still render).
- The allow-list lives in one place (poll/utils.py), so future tags/attributes are a one-line, reviewable change.
- CSV export keeps its existing strip-everything path (remove_markdown_and_html_tags) — unchanged.
- I also tidied up two spots where plain-text survey answer labels were being treated as trusted HTML so they're now handled the same (escaped) way they already were everywhere else in the same templates.

Testing

Verified locally that authored Markdown (headings, bold/italic, links, images) renders as before, and that the sanitization layer is exercised on every display path.